### PR TITLE
[LMB-26] feat: allow fetching the form definition

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -1,7 +1,17 @@
 import { app, errorHandler } from "mu";
+import { fetchFormDefinitionById } from "./form-repository";
 
 app.get("/", async function (_req, res) {
   res.send({ status: "ok" });
+});
+
+app.get("/:id", async function (_req, res) {
+  const form = await fetchFormDefinitionById(_req.params.id);
+  if (!form) {
+    res.send(404);
+    return;
+  }
+  res.send(form);
 });
 
 app.use(errorHandler);

--- a/form-repository.ts
+++ b/form-repository.ts
@@ -1,0 +1,25 @@
+import { query, sparqlEscapeString } from "mu";
+
+export const fetchFormDefinitionById = async function (id: string) {
+  const result = await query(`
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+    PREFIX sh: <http://www.w3.org/ns/shacl#>
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+
+    SELECT ?formDefinition ?formTtl
+    WHERE {
+      ?formDefinition a ext:GeneratedForm ;
+        mu:uuid ${sparqlEscapeString(id)} ;
+        ext:ttlCode ?formTtl .
+    } LIMIT 1
+  `);
+
+  if (result.results.bindings.length) {
+    const binding = result.results.bindings[0];
+    return {
+      formTtl: binding.formTtl.value,
+    };
+  } else {
+    return null;
+  }
+};


### PR DESCRIPTION
this allows fetching the form definition for a given form in the database.
The current model used by the form builder is used, but it feels like this is very much something we should change (?)
the form is requested from the database through SEAS so access rights are taken into account. This has been tested by running this service locally in concert with the rest of the LMB app