### PR TITLE
Construct for form paths

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -11,3 +11,4 @@
 !.*
 .*/
 .eslintcache
+.eslintrc.cjs

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -19,5 +19,14 @@ module.exports = {
     'linebreak-style': ['error', 'unix'],
     quotes: ['error', 'single'],
     semi: ['error', 'always'],
+    'no-unused-vars': 'off',
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        caughtErrorsIgnorePattern: '^_',
+      },
+    ],
   },
 };

--- a/app.ts
+++ b/app.ts
@@ -3,7 +3,7 @@ import {
   fetchFormDefinitionById,
   loadFormsFromConfig,
 } from './form-repository';
-import { cleanAndValidateFormTtl } from './form-validator';
+import { cleanAndValidateFormInstance } from './form-validator';
 import { ttlToInsert } from './utils';
 
 loadFormsFromConfig();
@@ -28,9 +28,13 @@ app.post('/:id', async function (req, res) {
     return;
   }
   // fetch form content from body
-  const { contentTtl } = req.body;
+  const { contentTtl, instanceUri } = req.body;
 
-  const validatedContent = await cleanAndValidateFormTtl(contentTtl, form);
+  const validatedContent = await cleanAndValidateFormInstance(
+    contentTtl,
+    form,
+    instanceUri,
+  );
 
   query(ttlToInsert(validatedContent));
 

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -1,0 +1,2 @@
+declare module 'forking-store';
+declare module 'mu';

--- a/form-validator.ts
+++ b/form-validator.ts
@@ -1,20 +1,132 @@
 import { NamedNode } from 'rdflib';
 import { FormDefinition } from './types';
 import ForkingStore from 'forking-store';
+import { sparqlEscapeUri } from 'mu';
+import { QueryEngine } from '@comunica/query-sparql';
+import N3 from 'n3';
+import { ttlToStore } from './utils';
+import { getPathsForFieldsQuery } from './queries/getPathsForFields';
 
-export const cleanAndValidateFormTtl = async function (
-  formTtl: string,
-  _form: FormDefinition,
-  placeholderInstanceUri?: string,
+const getPathsForFields = async function (formStore: N3.Store) {
+  type PathLink = { predicate: string; node: string };
+  const fieldPathStarts: Record<string, PathLink> = {};
+  const previousToNext: Record<string, PathLink> = {};
+
+  const results = await getPathsForFieldsQuery(formStore);
+
+  results.forEach((result) => {
+    const { predicate, previous, node, field } = result;
+    if (!previous) {
+      fieldPathStarts[field] = {
+        predicate,
+        node,
+      };
+    } else {
+      previousToNext[previous] = {
+        predicate,
+        node,
+      };
+    }
+  });
+
+  const fullPaths: Record<string, string[]> = {};
+  Object.keys(fieldPathStarts).forEach((field) => {
+    const path = fieldPathStarts[field];
+    let current = path;
+    const pathSteps: string[] = [];
+    while (current) {
+      pathSteps.push(current.predicate);
+      current = previousToNext[current.node];
+      if (!current) {
+        fullPaths[field] = pathSteps;
+      }
+    }
+  });
+  return fullPaths;
+};
+
+const pathToConstructVariables = function (
+  path: string[],
+  fieldIndex: number,
+  instanceUri: string,
 ) {
+  const instance = sparqlEscapeUri(instanceUri);
+  const variables = path.map((predicate, index) => {
+    const currentOrigin =
+      index === 0 ? instance : `?field${fieldIndex}var${index - 1}`;
+    if (predicate.startsWith('^')) {
+      return `?field${fieldIndex}var${index} ${predicate.substring(
+        1,
+      )} ${currentOrigin} .`;
+    }
+    return `${currentOrigin} ${predicate} ?field${fieldIndex}var${index} .`;
+  });
+  return variables.join('\n');
+};
+
+export const buildFormConstructQuery = async function (formTtl, instanceUri) {
+  const formStore = await ttlToStore(formTtl);
+  const formPaths = await getPathsForFields(formStore);
+
+  const constructVariables = Object.keys(formPaths).map((field, index) => {
+    return pathToConstructVariables(formPaths[field], index, instanceUri);
+  });
+  const constructPaths = constructVariables.map((path) => {
+    return `OPTIONAL { ${path} }`;
+  });
+
+  return `
+    PREFIX form:  <http://lblod.data.gift/vocabularies/forms/>
+    PREFIX sh: <http://www.w3.org/ns/shacl#>
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+    CONSTRUCT {
+      ${constructVariables.join('\n')}
+    } WHERE {
+      ${constructPaths.join('\n')}
+    }
+  `;
+};
+
+const extractFormDataTtl = async function (
+  dataTtl: string,
+  formTtl: string,
+  instanceUri: string,
+) {
+  const constructQuery = await buildFormConstructQuery(formTtl, instanceUri);
+  const constructStore = await ttlToStore(dataTtl);
+  const engine = new QueryEngine();
+  const bindings = await engine.queryQuads(constructQuery, {
+    sources: [constructStore],
+  });
+  const quads = await bindings.toArray();
+  return new Promise((resolve, reject) => {
+    const writer = new N3.Writer({ format: 'text/turtle' });
+    writer.addQuads(quads);
+    writer.end((error, result) => {
+      if (error) reject(error);
+      else resolve(result);
+    });
+  });
+};
+
+export const cleanAndValidateFormInstance = async function (
+  instanceTtl: string,
+  definition: FormDefinition,
+  instanceUri: string,
+) {
+  const definitionTtl = definition.formTtl;
   const store = new ForkingStore();
   const validationGraph = new NamedNode('http://data.lblod.info/validation');
-  await store.parse(formTtl, validationGraph);
+  await store.parse(instanceTtl, validationGraph);
 
-  // TODO throw if form is invalid
-  // TODO: LMB-29 create a construct query to clean the form input
-  const cleanedTtl = await store.serializeDataMergedGraph(validationGraph);
+  const parsedTtl = await store.serializeDataMergedGraph(validationGraph);
 
-  cleanedTtl.replace(placeholderInstanceUri, '');
+  const cleanedTtl = await extractFormDataTtl(
+    parsedTtl,
+    definitionTtl,
+    instanceUri,
+  );
+
   return cleanedTtl;
 };

--- a/form-validator.ts
+++ b/form-validator.ts
@@ -119,7 +119,7 @@ export const buildFormConstructQuery = async function (formTtl, instanceUri) {
     return pathToConstructVariables(allPaths[field], index, instanceUri);
   });
   const constructPaths = constructVariables.map((path) => {
-    return `OPTIONAL { ${path} }`;
+    return `OPTIONAL { ${path} }`; // TODO: For virtuoso, a UNION is faster, we may want to replace this BUT UNION is broken by comunica right now
   });
 
   return `

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
+        "@comunica/query-sparql": "^2.10.1",
         "body-parser": "^1.19.0",
         "cron": "^1.8.2",
         "crypto-js": "^4.0.0",
@@ -17,6 +18,7 @@
         "lodash.groupby": "^4.6.0",
         "lodash.uniq": "^4.5.0",
         "moment": "^2.29.1",
+        "n3": "^1.17.2",
         "rdflib": "^2.1.1",
         "uuid": "^8.3.1"
       },
@@ -45,6 +47,2308 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bergos/jsonparse": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@bergos/jsonparse/-/jsonparse-1.4.1.tgz",
+      "integrity": "sha512-vXIT0nzZGX/+yMD5bx2VhTzc92H55tPoehh1BW/FZHOndWGFddrH3MAfdx39FRc7irABirW6EQaGxIJYV6CGuA==",
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "dependencies": {
+        "buffer": "^6.0.3"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@comunica/actor-abstract-mediatyped": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-2.10.0.tgz",
+      "integrity": "sha512-0o6WBujsMnIVcwvRJv6Nj+kKPLZzqBS3On48rm01Rh9T1/My0E/buJMXwgcARKCfMonc2mJ9zxpPCh5ilGEU2A==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-abstract-parse": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-parse/-/actor-abstract-parse-2.10.0.tgz",
+      "integrity": "sha512-0puCWF+y24EDOOAUUVVbC+tOf4UV+LzEbqi8T5v25jcVGCXyTqfra+bDywfrcv3adrVp18jLCJ46ycaH5xhy9Q==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "readable-stream": "^4.4.2"
+      }
+    },
+    "node_modules/@comunica/actor-abstract-path": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-path/-/actor-abstract-path-2.10.1.tgz",
+      "integrity": "sha512-+k1ltuUuIyn4iUm5oRMObyt2zhu68h7ymzxuKU4ezATlgwfwj6EM7/3W2n2/gxjg9tcFMr5GC6aNnFQmq3Iuig==",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.10.1",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-string": "^1.6.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-context-preprocess-source-to-destination": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-source-to-destination/-/actor-context-preprocess-source-to-destination-2.10.0.tgz",
+      "integrity": "sha512-sQc42Sd4cuVumZ9+PDnWBTBYneqCFShFliK8Et83GR3wBGzu9x0tS/M2o3e63sBbb6ZkWHyO5jl/O8AbrjhcTg==",
+      "dependencies": {
+        "@comunica/bus-context-preprocess": "^2.10.0",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-dereference-fallback": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-fallback/-/actor-dereference-fallback-2.10.0.tgz",
+      "integrity": "sha512-RSc/ScPdC7l13aZjz/6r4niWA8WDETbzuESQKKSWXi/HAlFOyOxdrDADdayVY2oyeZHIQibeNRtSi2ItzU7OPQ==",
+      "dependencies": {
+        "@comunica/bus-dereference": "^2.10.0",
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-dereference-http": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-http/-/actor-dereference-http-2.10.0.tgz",
+      "integrity": "sha512-q+sJDjiyO/pwY9OwfzK6lS/gROhaqwFgWQNEjz1IuXLalqcFOjIiYqBuzhKLbtcFmXM+cnqWS2ZBtSFD4JLDhg==",
+      "dependencies": {
+        "@comunica/bus-dereference": "^2.10.0",
+        "@comunica/bus-http": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "cross-fetch": "^4.0.0",
+        "relative-to-absolute-iri": "^1.0.7",
+        "stream-to-string": "^1.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-dereference-http/node_modules/cross-fetch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
+    },
+    "node_modules/@comunica/actor-dereference-rdf-parse": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-rdf-parse/-/actor-dereference-rdf-parse-2.10.0.tgz",
+      "integrity": "sha512-ANWL6Bv+2WHUjVRS7hfkOfVBNJs8xYZ9KHlgBOQ94CKtQZB9uSMjdb1hLp/cQjiDmFIWLn0+GM5Xi0KFwBkVAw==",
+      "dependencies": {
+        "@comunica/bus-dereference": "^2.10.0",
+        "@comunica/bus-dereference-rdf": "^2.10.0",
+        "@comunica/bus-rdf-parse": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-hash-bindings-sha1": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-hash-bindings-sha1/-/actor-hash-bindings-sha1-2.10.0.tgz",
+      "integrity": "sha512-f981PcCiDWbdZfM1ct1v1q/VII14y18lo1enEdHB25SF0hCkzIDwh9IrfDfJDju5I6luSWNE/MYMMeAAmF9e3g==",
+      "dependencies": {
+        "@comunica/bus-hash-bindings": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "canonicalize": "^2.0.0",
+        "hash.js": "^1.1.7",
+        "rdf-string": "^1.6.1"
+      }
+    },
+    "node_modules/@comunica/actor-hash-bindings-sha1/node_modules/canonicalize": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-2.0.0.tgz",
+      "integrity": "sha512-ulDEYPv7asdKvqahuAY35c1selLdzDwHqugK92hfkzvlDCwXRRelDkR+Er33md/PtnpqHemgkuDPanZ4fiYZ8w=="
+    },
+    "node_modules/@comunica/actor-http-fetch": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-fetch/-/actor-http-fetch-2.10.1.tgz",
+      "integrity": "sha512-d0Eo/ZVu4mr5zpIonT9pf9JUpohxImJZAeZUleVdGYgvzB7AD6CFrtW+0fVeP2/9WDYAHubokSn4gzj0UojvyA==",
+      "dependencies": {
+        "@comunica/bus-http": "^2.10.0",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/mediatortype-time": "^2.10.0",
+        "abort-controller": "^3.0.0",
+        "cross-fetch": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-http-fetch/node_modules/cross-fetch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
+    },
+    "node_modules/@comunica/actor-http-proxy": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-2.10.0.tgz",
+      "integrity": "sha512-WpwjGRZcIPcnR8OVumrlmLPfYR5livQsUbOPqmYFDxjI+xDfuOYvCPc/uLyYyBpMH10dejmaRWeCUsIguZz5ZQ==",
+      "dependencies": {
+        "@comunica/bus-http": "^2.10.0",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/mediatortype-time": "^2.10.0",
+        "@comunica/types": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-http-wayback": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-wayback/-/actor-http-wayback-2.10.0.tgz",
+      "integrity": "sha512-dwSTkXgXhWrVeBURJWvRrdRnPiCa0ywhSq58+UPE+6w6y4MgHH3v1Ee7SuC3zVl39vLx1i0LtiyA8Oi1qqRGBg==",
+      "dependencies": {
+        "@comunica/bus-http": "^2.10.0",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "cross-fetch": "^4.0.0",
+        "stream-to-string": "^1.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-http-wayback/node_modules/cross-fetch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
+    },
+    "node_modules/@comunica/actor-init-query": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-init-query/-/actor-init-query-2.10.1.tgz",
+      "integrity": "sha512-+FTGJm9pef0FQmD08sAAZhBzB6Rd7D8aXScpe5Fj4asMHV8lVQbncYL/mQP04LmMA72Ntdu02Q9uFyjC0GjWSw==",
+      "dependencies": {
+        "@comunica/actor-http-proxy": "^2.10.0",
+        "@comunica/bus-context-preprocess": "^2.10.0",
+        "@comunica/bus-http-invalidate": "^2.10.0",
+        "@comunica/bus-init": "^2.10.0",
+        "@comunica/bus-optimize-query-operation": "^2.10.0",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-query-parse": "^2.10.0",
+        "@comunica/bus-query-result-serialize": "^2.10.0",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/logger-pretty": "^2.10.0",
+        "@comunica/runner": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "@types/yargs": "^17.0.24",
+        "asynciterator": "^3.8.1",
+        "negotiate": "^1.0.1",
+        "rdf-quad": "^1.5.0",
+        "rdf-string": "^1.6.1",
+        "sparqlalgebrajs": "^4.2.0",
+        "streamify-string": "^1.0.1",
+        "yargs": "^17.7.2"
+      },
+      "optionalDependencies": {
+        "process": "^0.11.10"
+      }
+    },
+    "node_modules/@comunica/actor-optimize-query-operation-bgp-to-join": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-bgp-to-join/-/actor-optimize-query-operation-bgp-to-join-2.10.0.tgz",
+      "integrity": "sha512-M9vwM4a3VQA/ir8Q7eGRNzzx52u6RJFIXBW8p+Zkn+zv+4fsket3zLYJGhJU7dcvaSXcOi68rDP/r8KfgNXr4Q==",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-optimize-query-operation-join-bgp": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-2.10.0.tgz",
+      "integrity": "sha512-tzZojWPbWn/S0DZGjGfV90ZRJVWT/yX3DKGgZ1ur33U5TW8n/fBQxHNMPCLu0GkMQ1dyx6bU+ekILTqm+21Jyw==",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-optimize-query-operation-join-connected": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-connected/-/actor-optimize-query-operation-join-connected-2.10.0.tgz",
+      "integrity": "sha512-RsbKIAxX1HyoR/AUzqIV++dTcLiEElRIVDHYTaXVVvGgHECYdh9s+oc8cvv/lDbLVpfnc6P9C9BTAfrqOjKkhA==",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-ask": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-ask/-/actor-query-operation-ask-2.10.1.tgz",
+      "integrity": "sha512-7oktqE4fkMhi6Hs9XCcwwoZRsEismVqJZ5wp9lXXOPaxnHEiFyj5gb/B6baCstoCvCt6LcU8fVvfHSitbFCpeQ==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-bgp-join": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-join/-/actor-query-operation-bgp-join-2.10.1.tgz",
+      "integrity": "sha512-eNpnvgFyKlZEHkMzubYL8ndADSsAQH4rwXvh22CGnf0FwyndHr6TEpmE6j77m9vXiSJ/lda0U3Zv4vIXvtREOw==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-construct": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-construct/-/actor-query-operation-construct-2.10.1.tgz",
+      "integrity": "sha512-S+Nt1+1psv01QRnfytZjiog2NBNHIbjr7XIv+MO3p6aVmLCoZ6lmjxSGNdbX+EmcGr7tbbafXK5z3zRM+ke8Mw==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-terms": "^1.11.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-describe-subject": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-describe-subject/-/actor-query-operation-describe-subject-2.10.1.tgz",
+      "integrity": "sha512-E8i0M6haJ5iZVeHMn5PbvA4G+l87mcZKqIxVpYAnJVpD667F74Dkx3IMbk+ohRmyRmnkOEmztUrjeyixHHzUEQ==",
+      "dependencies": {
+        "@comunica/actor-query-operation-union": "^2.10.1",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "asynciterator": "^3.8.1",
+        "rdf-data-factory": "^1.1.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-distinct-hash": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-distinct-hash/-/actor-query-operation-distinct-hash-2.10.1.tgz",
+      "integrity": "sha512-exvJbgcJ0Pe4EGbLJD5LuGpvaGcFeckCxwB5pyd9OewNke+tLLP7nbEjB8KFEPpCO9LE7zt4faB1HvpJdEHQKQ==",
+      "dependencies": {
+        "@comunica/bus-hash-bindings": "^2.10.0",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-extend": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-2.10.1.tgz",
+      "integrity": "sha512-wkZxUfDu8T5lXD+OFLItmjjbnEBqtv0z8pxVKgI/gX8mOeu5KcPWLH0dJODTWoIzIYrJhV25FmCgBks1rt6K8w==",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.10.1",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/expression-evaluator": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-filter-sparqlee": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-filter-sparqlee/-/actor-query-operation-filter-sparqlee-2.10.1.tgz",
+      "integrity": "sha512-w2PnDNnlf+9B947ZdeSs7NpW9qGJjRiuODZYwhh0e6cx89GPDhEDVuJwawF6VP3m/oLcgXOAdif0Wwo3d8KNAA==",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.10.1",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/expression-evaluator": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-from-quad": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-2.10.1.tgz",
+      "integrity": "sha512-7D4R8ONNJJPzoRu96dwIToOEk6/3O/T26FRzCqQKrbjFHNkX2v92KA/SiDzNz59VmDNWjYF1rsV31Ade6J89MA==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-group": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-group/-/actor-query-operation-group-2.10.1.tgz",
+      "integrity": "sha512-Od5s9Vb6uDPzXa6OAUC1WSMF96spNPJI2Zqf0Ixejw4zCNevOK/VwHivYfF0vHIUZxjRrOl3Al1ZU9L8n5Wxlw==",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.10.1",
+        "@comunica/bus-hash-bindings": "^2.10.0",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/expression-evaluator": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "rdf-data-factory": "^1.1.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-join": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-join/-/actor-query-operation-join-2.10.1.tgz",
+      "integrity": "sha512-CGed1nSPvKsM8rvj/4KFME0lLnzlDMMEU+xGczu+BZW4FK+Z6RyBtHIUmy8SgFvNP1GXz83q8KnoecF5z8IpjA==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-rdf-join": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-leftjoin": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin/-/actor-query-operation-leftjoin-2.10.1.tgz",
+      "integrity": "sha512-j0RwdoiV2WsCQnxcSa//m5FZ+ZHDRBm6ObsgpqS44WxzpV8rIB6Dq/3UxGgE7D2vK400JaiiHa3dFiHTwDF18w==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-rdf-join": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/expression-evaluator": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-minus": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-minus/-/actor-query-operation-minus-2.10.1.tgz",
+      "integrity": "sha512-rUvHbc5/EUWMSJUgOEtxabCJ9IT9YThuG0FhcQk+BGRPGmsv2oz8uri5urKgCjfVXMH/09hRZksiDMqrmkQmZw==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-rdf-join": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-nop": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-nop/-/actor-query-operation-nop-2.10.1.tgz",
+      "integrity": "sha512-l/Z8Uuoq3AlSoxkgYjrP7O7Xc9h8Y3ZOh0f7UKCuAST3U5vPQ3k1YJckrRtdli8s0NHptN9TfZjwviEHuYbDFQ==",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.10.1",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/metadata": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "asynciterator": "^3.8.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-orderby-sparqlee": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-orderby-sparqlee/-/actor-query-operation-orderby-sparqlee-2.10.1.tgz",
+      "integrity": "sha512-8D2JmCsBtqJC29zfiaAXNzZdsKybhDFo2F8iTHul3nQHxBC2CeKDrBnY70B/HpbWxkDE+pwMfSTEFc/CvNZN6A==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/expression-evaluator": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "asynciterator": "^3.8.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-alt": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-2.10.1.tgz",
+      "integrity": "sha512-y1AHtkibThqHve79wAriXqrZ6hdLBhcdwyOpVqqEhY19a32P97Xv58bOwOkNeLguYdn/5CFlCTHz6dnzxUIoXg==",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^2.10.1",
+        "@comunica/actor-query-operation-union": "^2.10.1",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/types": "^2.10.0",
+        "asynciterator": "^3.8.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-inv": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-2.10.1.tgz",
+      "integrity": "sha512-pd30Ug7bOAZ5amfA3I6v+cpitlDn2i5fE1BA006LYJISCAHSfKEgLmU2Q4ZPbwi4s1A8WKKLV7Q389Ru3Xtziw==",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^2.10.1",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-link": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-2.10.1.tgz",
+      "integrity": "sha512-akujCHvCLmxaZ3gw9b1odDcqqAQnbbr9E8dTWLZyMJ4Mei8q/FmfWTF5MjGuQOas4UmQ3mm6gcqAKRZnJqlXNg==",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^2.10.1",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-nps": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-2.10.1.tgz",
+      "integrity": "sha512-5X3EUzn6Cygz94gNn1XWQQUZVp+de59sw8/rxPQqgwzdi1Y1O9zrLv+/7GqMJoLz6MHmDSgsceTIY4eC1qmmOQ==",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^2.10.1",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-one-or-more": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-2.10.1.tgz",
+      "integrity": "sha512-SkQeKESQqZOlzuMIsipcZ3ni7YfeyYMZCOtxC01HFbeyq+SDVbyfYUZ4Dd9uAi/g3InyzJRfou4csxHS8g7sHw==",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^2.10.1",
+        "@comunica/bindings-factory": "^2.10.1",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/types": "^2.10.0",
+        "asynciterator": "^3.8.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-seq": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-2.10.1.tgz",
+      "integrity": "sha512-8TYLdVYaq9oMd9cuLFay78103bOfvygQU/C8NtPdLI9kkRWFsBatvaKmykHOHQAvaLgNhniOlrIJNEpepZGnAQ==",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^2.10.1",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-rdf-join": "^2.10.1",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-zero-or-more": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-2.10.1.tgz",
+      "integrity": "sha512-DtqBSw4LV1KI3q1YYAwgXlWrz1PO4EUpe/bVri0UB3JSQnxjBMHuJlHn2crC9Z93tmizneXxfvtWlLSXRrehsw==",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^2.10.1",
+        "@comunica/bindings-factory": "^2.10.1",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/types": "^2.10.0",
+        "asynciterator": "^3.8.1",
+        "rdf-string": "^1.6.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-zero-or-one": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-2.10.1.tgz",
+      "integrity": "sha512-qePX+7iW5DXDwaYO210y7jhSU32Zk82S5UHuLLvd4q4HS1Z7j8e4KhukbeZKzQmOsO8S5JOHHM9vwvsOc3GPlw==",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^2.10.1",
+        "@comunica/bindings-factory": "^2.10.1",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/metadata": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "asynciterator": "^3.8.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-project": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-project/-/actor-query-operation-project-2.10.1.tgz",
+      "integrity": "sha512-KAaPl4GFIQMWR8I8OoJroktGssPKGbEEJHyGzTuYXrmJrcXgknOxf5IUSVJNpaFfS6dshT6nqW+ciT+wRzz0Tg==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/data-factory": "^2.7.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-quadpattern": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-quadpattern/-/actor-query-operation-quadpattern-2.10.1.tgz",
+      "integrity": "sha512-RZj1TXW+VDU4aYJVnSzgs8q0340e+YUeGLtoY9sl0Xzc8YNaIus4nXRUz/KfOXDknxm1q+a4Bof4yHNgXtb1Hw==",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.10.1",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.10.0",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-string": "^1.6.3",
+        "rdf-terms": "^1.11.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-reduced-hash": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-reduced-hash/-/actor-query-operation-reduced-hash-2.10.1.tgz",
+      "integrity": "sha512-9hX25ztkbNxnaUd7Gtilok+9WJkr/s3a3y4axLoYX4/nOogYN+nZRKChvNSn4qn/lWvpG5VWv4+q0en1fP+AGA==",
+      "dependencies": {
+        "@comunica/bus-hash-bindings": "^2.10.0",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "lru-cache": "^10.0.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-reduced-hash/node_modules/lru-cache": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
+      "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-service": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-service/-/actor-query-operation-service-2.10.1.tgz",
+      "integrity": "sha512-GvpvhUmhkVFOCLrmcblgIPqi91XPRog5WkC9NFMRCToaSNAMQq82DX2dvwzn3IFItcmyZrmy+GYoaQ9miK2uVQ==",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.10.1",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/metadata": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "asynciterator": "^3.8.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-slice": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-slice/-/actor-query-operation-slice-2.10.1.tgz",
+      "integrity": "sha512-KOBnTIUvwf28WB7oHevUC/xciEdH5gLg7MN8DvamkAkUiUjviEsRpkswUiD8lFe1dAs0ekA4pC0NoZ8BWp3uqA==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-sparql-endpoint": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-sparql-endpoint/-/actor-query-operation-sparql-endpoint-2.10.1.tgz",
+      "integrity": "sha512-rV+MROUJq07O6KRAh7GtqFLR+raOytf6P9ImNnHNHntiO2ijijWSOdwfiDPkK99aJLqHrma0tlApFnbjeIfVig==",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.10.1",
+        "@comunica/bus-http": "^2.10.0",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.10.0",
+        "@comunica/bus-rdf-update-quads": "^2.10.1",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/mediatortype-httprequests": "^2.10.0",
+        "@comunica/metadata": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "fetch-sparql-endpoint": "^4.1.0",
+        "rdf-data-factory": "^1.1.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-union": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-union/-/actor-query-operation-union-2.10.1.tgz",
+      "integrity": "sha512-Ezi2bAa9r6yyffXDDUPLlKoszsXnuhDUeQSQuU3c7JEAcwip3wC3zMNkavowwfRZ/1D5doitmUEdw2lAd+xloA==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/metadata": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "rdf-terms": "^1.11.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-add-rewrite": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-add-rewrite/-/actor-query-operation-update-add-rewrite-2.10.1.tgz",
+      "integrity": "sha512-is3mrCPciExrlny5JbCvB011kUNYE9/fzQc/zmA3h24S5hHZbygA9mSS+dI85IwwqdKPYlrEqfn8c0kCVWMKyw==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "rdf-data-factory": "^1.1.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-clear": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-clear/-/actor-query-operation-update-clear-2.10.1.tgz",
+      "integrity": "sha512-t9Dw20Hmf3v11nwHGriFiAUAP9vWkYUCbtyaConcIN7GhPcI8YD0U+ysmQCUWzQ9EaNKOxM1da7XRJ7fnS3toA==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-rdf-update-quads": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-compositeupdate": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-compositeupdate/-/actor-query-operation-update-compositeupdate-2.10.1.tgz",
+      "integrity": "sha512-IVNouBPFQLOczhW3qHyEoyxWrc7wnVT2vPwRHEaGlfnSiYAX42XSNLb9jR0XjB70wh3Civue4Ovs3upOXdrN3Q==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-copy-rewrite": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-copy-rewrite/-/actor-query-operation-update-copy-rewrite-2.10.1.tgz",
+      "integrity": "sha512-l/3AM35hjahyHmiLoB3FPm0Jlhdmd/vqgOGj7V3Ra+TfHo5h8XOB3uzG78Q06HQNw4iyONBZc5lLlYXkzRd5lg==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-create": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-create/-/actor-query-operation-update-create-2.10.1.tgz",
+      "integrity": "sha512-6LLxof7gTXnO3ELl2hGf1MUUkpKzLMmx2I9Q1ciGkoHgv5S+btxMhZFjN89nL5CDWs8A8uwwmI5CpN/xZMFPrg==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-rdf-update-quads": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-deleteinsert": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-deleteinsert/-/actor-query-operation-update-deleteinsert-2.10.1.tgz",
+      "integrity": "sha512-VDGv0hHIp3lns4n11i7SiHXNnxSLiYR+Y5dZQHZQFG8+szOjZIJq171/N6f5pD8KM7pOtn/J7zE+8VWx2Lmagg==",
+      "dependencies": {
+        "@comunica/actor-query-operation-construct": "^2.10.1",
+        "@comunica/bindings-factory": "^2.10.1",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-rdf-update-quads": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-drop": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-drop/-/actor-query-operation-update-drop-2.10.1.tgz",
+      "integrity": "sha512-S5oQtHepeQD45K4rihgXmoIILmsbkz66libpm0fqUkkqWXUCme06C5rBWO53Ad/ZUeCRp9jv30VXOr7iPX7DbQ==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-rdf-update-quads": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-load": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-load/-/actor-query-operation-update-load-2.10.1.tgz",
+      "integrity": "sha512-rCgI9kuXNPAWPn6mFLZPZ2MWMLgApLn0juGjGt9b9V07Xm8xVFIRWoMsb55R0rFgp/2U/YGz1Z5RSRgOe6mQaA==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-rdf-update-quads": "^2.10.1",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "rdf-data-factory": "^1.1.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-move-rewrite": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-move-rewrite/-/actor-query-operation-update-move-rewrite-2.10.1.tgz",
+      "integrity": "sha512-GDLSHG2++EAAyUKhDu+mM6QfMTuzM8dS24HqeQL5Wzbkdc2KTmNKyJuhJw6SfXr6EiF/kxf1GPY6zwjcwACx/w==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-values": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-values/-/actor-query-operation-values-2.10.1.tgz",
+      "integrity": "sha512-++9IgCVCQPIF8fzZLmrVpxPj8eI9TvkLshHAugQQBnhSijrDMUudW9eoA+eFmCaD/Ru7YtlKe3OJzRGV8FCG+Q==",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.10.1",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/metadata": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "asynciterator": "^3.8.1",
+        "rdf-data-factory": "^1.1.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-parse-graphql": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-parse-graphql/-/actor-query-parse-graphql-2.10.0.tgz",
+      "integrity": "sha512-l3RrkxElDYV4weXt3vpC0Q0She4AhbvPbPDronQulgN9nFAZhz4z9k8800T5uWMsL98wHNNXDFlnFk5S38lsow==",
+      "dependencies": {
+        "@comunica/bus-query-parse": "^2.10.0",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "graphql-to-sparql": "^3.0.1"
+      }
+    },
+    "node_modules/@comunica/actor-query-parse-sparql": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-parse-sparql/-/actor-query-parse-sparql-2.10.0.tgz",
+      "integrity": "sha512-DUVAuSSNn0AyvLruOpRpLZBsr96Q4LuV1gcO+alKZALtfOZikRKY/3sXz1NUkaRQc7qDH9xFFTFrfJd0jLvlDA==",
+      "dependencies": {
+        "@comunica/bus-query-parse": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@types/sparqljs": "^3.1.3",
+        "sparqlalgebrajs": "^4.2.0",
+        "sparqljs": "^3.7.1"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-json": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-json/-/actor-query-result-serialize-json-2.10.0.tgz",
+      "integrity": "sha512-GuVcsOEhKgnVPT0AaCn8sJl/Uj5UUjUktEJpuMx1UAYt0//jcQsezJslYWmJrfXE/WJYidynyDxm8z3+jwLF7A==",
+      "dependencies": {
+        "@comunica/bus-query-result-serialize": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "rdf-string": "^1.6.1",
+        "readable-stream": "^4.4.2"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-rdf": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-rdf/-/actor-query-result-serialize-rdf-2.10.0.tgz",
+      "integrity": "sha512-TBXJrDs5brRMFg8UisXS/F1vJw8nUtLhjugNZcd4ST8J965Ho1aNopydp4PMmwINMRxHhHtWJGwIB2Z5xD2lDw==",
+      "dependencies": {
+        "@comunica/bus-query-result-serialize": "^2.10.0",
+        "@comunica/bus-rdf-serialize": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-simple": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-simple/-/actor-query-result-serialize-simple-2.10.0.tgz",
+      "integrity": "sha512-pS7+aB9Rym1B5oi+O68NFjEq+EwpCRYtTIxGBp39CTQ0F7m4edt9QwqmARqveJPryK5X66ACvjxvutEaTgWI8w==",
+      "dependencies": {
+        "@comunica/bus-query-result-serialize": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "rdf-string": "^1.6.3",
+        "readable-stream": "^4.4.2"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-sparql-csv": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-sparql-csv/-/actor-query-result-serialize-sparql-csv-2.10.0.tgz",
+      "integrity": "sha512-Vk+7oTIPigDENK3CnV56vLfvMZVjHc3p2F4a49WDHfMgRrfQKJSQkx603vjW35n3tmUB8JSgRXr/+v7LK83KYQ==",
+      "dependencies": {
+        "@comunica/bus-query-result-serialize": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "readable-stream": "^4.4.2"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-sparql-json": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-sparql-json/-/actor-query-result-serialize-sparql-json-2.10.0.tgz",
+      "integrity": "sha512-Y0z9qy30tkVWZVwSAfYOhhbfwoPO15s6XHTY8iPIZw9w/5CrbAD0wo9L0XAUimiiB6xx2mbtdexpuzu/2qVeYA==",
+      "dependencies": {
+        "@comunica/bus-http": "^2.10.0",
+        "@comunica/bus-http-invalidate": "^2.10.0",
+        "@comunica/bus-query-result-serialize": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "readable-stream": "^4.4.2"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-sparql-tsv": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-sparql-tsv/-/actor-query-result-serialize-sparql-tsv-2.10.0.tgz",
+      "integrity": "sha512-TgA2WIXKdu/SrbHEP8HvGoLjhDOZnBoHsGsLFSHpxY/Uwk21rZqJLBEkhuhkUtGYzQPJ1n6Wmpjz9lBrUHGJPw==",
+      "dependencies": {
+        "@comunica/bus-query-result-serialize": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "rdf-string-ttl": "^1.3.2",
+        "readable-stream": "^4.4.2"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-sparql-xml": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-sparql-xml/-/actor-query-result-serialize-sparql-xml-2.10.0.tgz",
+      "integrity": "sha512-8RDj5ZN23HnIc6zI5pD5XKi2pyg2cx6DhI7VDRcboi7v0DxfROuQqSEtbQ8m/W6Pngdz01ySogRcIVJCzRzBLQ==",
+      "dependencies": {
+        "@comunica/bus-query-result-serialize": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "readable-stream": "^4.4.2"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-stats": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-stats/-/actor-query-result-serialize-stats-2.10.0.tgz",
+      "integrity": "sha512-Aa2ijQLLgnMFefmyrEBE1CZjlyDIPFDQXfMJfphCjEzN5nOOsZax2E5DK31tEaJyOQV/8Af5X1YamiOoNMZSWw==",
+      "dependencies": {
+        "@comunica/bus-http": "^2.10.0",
+        "@comunica/bus-http-invalidate": "^2.10.0",
+        "@comunica/bus-query-result-serialize": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "process": "^0.11.10",
+        "readable-stream": "^4.4.2"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-table": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-table/-/actor-query-result-serialize-table-2.10.0.tgz",
+      "integrity": "sha512-AAPrgM/rbsSThRu9jkfJhBUeTUwQTLHNVbIn8El+Akvz+Fueoi6oSi3SslpPMHOvIUiOAgCZ05f2RbBLlhP03g==",
+      "dependencies": {
+        "@comunica/bus-query-result-serialize": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-string": "^1.6.3",
+        "rdf-terms": "^1.11.0",
+        "readable-stream": "^4.4.2"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-tree": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-tree/-/actor-query-result-serialize-tree-2.10.0.tgz",
+      "integrity": "sha512-sEyIzoSTV11YPY6r4fn6fwrf3WjLD6GrwXMTuevsDAKDYaMYxyriH3T/LMLLBEURy8SLD1I1Fpw/qaZisRmLTg==",
+      "dependencies": {
+        "@comunica/bus-query-result-serialize": "^2.10.0",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "readable-stream": "^4.4.2",
+        "sparqljson-to-tree": "^3.0.1"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-entries-sort-cardinality": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-entries-sort-cardinality/-/actor-rdf-join-entries-sort-cardinality-2.10.0.tgz",
+      "integrity": "sha512-6dd/29q6QuQN2Ap090VA0KUFmmnHalPxFJb4MGh5nIbWZH0F/EvI+uK5vPx29cttr1yXL5u+MbJWaLb3IxwILg==",
+      "dependencies": {
+        "@comunica/bus-rdf-join-entries-sort": "^2.10.0",
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-hash": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-hash/-/actor-rdf-join-inner-hash-2.10.1.tgz",
+      "integrity": "sha512-nUtdS3NJGKSJQC8KjDVz4TEDmkXHBYQi0/bwnAXCDl1phhq8lgv+YEmRDNe/kuCze7HyqEt98rlSJ+ZhvcHXVQ==",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^2.10.1",
+        "@comunica/mediatortype-join-coefficients": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "asyncjoin": "^1.1.1"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-multi-bind": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-bind/-/actor-rdf-join-inner-multi-bind-2.10.1.tgz",
+      "integrity": "sha512-tNZ2Q7z44Yr0iIFkvtTVAsts4v0IoC4b0FYaIUeYav4y5JOlR74hWWijTAzVfb31dTMsAp3r+y0xGIdd75LRHQ==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-rdf-join": "^2.10.1",
+        "@comunica/bus-rdf-join-entries-sort": "^2.10.0",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/mediatortype-join-coefficients": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "asynciterator": "^3.8.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-multi-empty": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-empty/-/actor-rdf-join-inner-multi-empty-2.10.1.tgz",
+      "integrity": "sha512-z6a3qENwuvSU0PvqOySrsHsWSUvzfWd1xIYwEvKuEIJ9vYPoefIUgggx08E95ZF/k+PxZ0vKEywFpBSUKUzGYA==",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^2.10.1",
+        "@comunica/mediatortype-join-coefficients": "^2.10.0",
+        "@comunica/metadata": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "asynciterator": "^3.8.1"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-multi-smallest": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-smallest/-/actor-rdf-join-inner-multi-smallest-2.10.1.tgz",
+      "integrity": "sha512-MXwIvq+viDCmsxJwD4+fwMhwZINWva3jtQ3j5ne6DXgZYUJUFOw3VujvCP4/cl075RuSxYlXgy6ETHLa1TNr7g==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-rdf-join": "^2.10.1",
+        "@comunica/bus-rdf-join-entries-sort": "^2.10.0",
+        "@comunica/mediatortype-join-coefficients": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-nestedloop": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-nestedloop/-/actor-rdf-join-inner-nestedloop-2.10.1.tgz",
+      "integrity": "sha512-nFjGMrAIrRjRcsaU8UQXLbsDODVdf4LDpVNVQIrjfoWzhOIy13ApDQrqtuObaGVfryiFgt34zVEOwMWezWzl0A==",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^2.10.1",
+        "@comunica/mediatortype-join-coefficients": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "asyncjoin": "^1.1.1"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-none": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-none/-/actor-rdf-join-inner-none-2.10.1.tgz",
+      "integrity": "sha512-4mqsuqvLSuXMbgY0PghqK5hmBGH5YkRTwUOpGpBE0EVQaiAoQOME0uVslkt2TBzUx5IQJC+trr/80sbA9mAhMw==",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.10.1",
+        "@comunica/bus-rdf-join": "^2.10.1",
+        "@comunica/mediatortype-join-coefficients": "^2.10.0",
+        "@comunica/metadata": "^2.10.0",
+        "asynciterator": "^3.8.1"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-single": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-single/-/actor-rdf-join-inner-single-2.10.1.tgz",
+      "integrity": "sha512-RfnwTEsuXNdR0cNRWaCvNPlfD5KyuScsc/55j/9mr8yqGUTE9h9Om1Is5u7xnpRMxGOEqwVP6apK3ZxsZqlL/w==",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^2.10.1",
+        "@comunica/mediatortype-join-coefficients": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-symmetrichash": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-symmetrichash/-/actor-rdf-join-inner-symmetrichash-2.10.1.tgz",
+      "integrity": "sha512-beFGkMUe3pTADtMXXPU8ab/IMULj+Hkg3Iah0zgrVZgwWH1Kgfkj/2qp32Ll5y9qcRbio4ruruKlHNXJJUU46Q==",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^2.10.1",
+        "@comunica/mediatortype-join-coefficients": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "asyncjoin": "^1.1.1"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-minus-hash": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-minus-hash/-/actor-rdf-join-minus-hash-2.10.1.tgz",
+      "integrity": "sha512-wIaB/EpuySaARhimoLzrE0cTH0TgVkL43IAtYX7ECwH9Qcv8blO4zbL4q2KUkY7OKZRM892aqMfo3kO1vMIK7w==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-rdf-join": "^2.10.1",
+        "@comunica/mediatortype-join-coefficients": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-minus-hash-undef": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-minus-hash-undef/-/actor-rdf-join-minus-hash-undef-2.10.1.tgz",
+      "integrity": "sha512-tz5LdeAHnylEQIq4bRfFqaH89WZXkkdFxEshqxWijFBp5wprUYiotMDrBo9zDFaPquhs42fILtTzLY9yaalc9w==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-rdf-join": "^2.10.1",
+        "@comunica/mediatortype-join-coefficients": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "rdf-string": "^1.6.1"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-optional-bind": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-bind/-/actor-rdf-join-optional-bind-2.10.1.tgz",
+      "integrity": "sha512-6dOoI/rzRZ0RUyv2WlToClE42Z2YJE5xcSrot7haT2eMdxbzr1KjyasHBcIIkSK+WViDO006lXZ1Hi4tJm9uuA==",
+      "dependencies": {
+        "@comunica/actor-rdf-join-inner-multi-bind": "^2.10.1",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-rdf-join": "^2.10.1",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/mediatortype-join-coefficients": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-optional-nestedloop": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-nestedloop/-/actor-rdf-join-optional-nestedloop-2.10.1.tgz",
+      "integrity": "sha512-d7KUDjEKZszizd4SBvYkK2A6lScrq9ciEgzdrrp6IYZhIGAhJLTgPNg3Js3NEjpE7oj4KWl2WwKJe2sWcJbKJg==",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^2.10.1",
+        "@comunica/mediatortype-join-coefficients": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "asyncjoin": "^1.1.1"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-selectivity-variable-counting": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-selectivity-variable-counting/-/actor-rdf-join-selectivity-variable-counting-2.10.0.tgz",
+      "integrity": "sha512-D7tdzxA93bpZGXI5emJyvzk6LabeAnzcQMU/V5x2QwJxyoNr+LFbesBHDDP3/u4UJwmeP0a+dU0e5mbpJujSXw==",
+      "dependencies": {
+        "@comunica/bus-rdf-join-selectivity": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/mediatortype-accuracy": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-accumulate-cancontainundefs": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-cancontainundefs/-/actor-rdf-metadata-accumulate-cancontainundefs-2.10.0.tgz",
+      "integrity": "sha512-N3rwX4kT9rkW+89q4xCjO3KKG0DbeNIyeMWDzeh2vTw8nAXYyTiPjHYvx/6VUMzhFUWF+50VtVv8ZJPO6nEapw==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-accumulate": "^2.10.0",
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-accumulate-cardinality": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-cardinality/-/actor-rdf-metadata-accumulate-cardinality-2.10.0.tgz",
+      "integrity": "sha512-UpC5PbhzEDCAxTUqETH89uRaFRqmP6YuWt67OAPo5wocv2tQDs6/SdLwS695XnfeMJdfDHsXyoUzQg3r8dwydw==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-accumulate": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-accumulate-pagesize": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-pagesize/-/actor-rdf-metadata-accumulate-pagesize-2.10.0.tgz",
+      "integrity": "sha512-r364CWGr5rMpV2ec3TsD+9Yhvi1JUuRXLBQqtgzjAPbpWjfDSM1Q4h0P1z9h3D+sdUMEX/0iGAY3AH2FjJAxwA==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-accumulate": "^2.10.0",
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-accumulate-requesttime": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-requesttime/-/actor-rdf-metadata-accumulate-requesttime-2.10.0.tgz",
+      "integrity": "sha512-SpG7gxxAPoW2NbgyZ2UNpwluJ+IvCOYIRDTXmVTAK8bntav+/ZG30yfESFBjB3LmJEwAnktAsTgM6OhldohPKw==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-accumulate": "^2.10.0",
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-all": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-all/-/actor-rdf-metadata-all-2.10.0.tgz",
+      "integrity": "sha512-dHaSxHTdneWVBMAF6WqZrGD+u4TPpHQaJ2WutK1NvQNPIiF0N7249aGTvXBIXZfsKYyQ73PUORDeLEOjX+tT7g==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "readable-stream": "^4.4.2"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-extract-allow-http-methods": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-allow-http-methods/-/actor-rdf-metadata-extract-allow-http-methods-2.10.0.tgz",
+      "integrity": "sha512-aCSX+lWcmz5Q/g34VJEblczqDS6N+gJ3AlcOcGuqhd6qHRU17dMeCIZCk8p6p+AhbJ30w4BTsrZRY2sF0MGCVA==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-extract": "^2.10.0",
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-extract-hydra-controls": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-controls/-/actor-rdf-metadata-extract-hydra-controls-2.10.0.tgz",
+      "integrity": "sha512-T6F5OaQNqrHVIwSGNRX6YPDBoAOYBQj3NTPID7vQae7J80oEX+CLoTkeJJwfHpoUWx0ihs8J0UkABgK3AWeylA==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-extract": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@rdfjs/types": "*",
+        "@types/uritemplate": "^0.3.4",
+        "uritemplate": "0.3.4"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-extract-hydra-count": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-count/-/actor-rdf-metadata-extract-hydra-count-2.10.0.tgz",
+      "integrity": "sha512-nOMLN+9OSLFOVz6jc9pcyDizhcBBVT2azn7StTMK5ukFCcPCENS4y6lYhC5cijKZY7vUa7U6VzhX2vvw20MKDA==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-extract": "^2.10.0",
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-extract-hydra-pagesize": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-pagesize/-/actor-rdf-metadata-extract-hydra-pagesize-2.10.0.tgz",
+      "integrity": "sha512-mD8KS2ENr2rbfBWxtVpxkB/Y2LyyAnwQU5UYKkpet8ELhlostdGROzYCNIAgfOgirOAsLgVkbmrX0XBGouI7rA==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-extract": "^2.10.0",
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-extract-patch-sparql-update": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-patch-sparql-update/-/actor-rdf-metadata-extract-patch-sparql-update-2.10.0.tgz",
+      "integrity": "sha512-U5ARpeWKShbbSfdtJeb6nyPcsdtMwEo2dp56T4aSTNSBKtAhQ78DjOxb23WIU/VR/qpw2yWcsbPnNJvSaLpRVQ==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-extract": "^2.10.0",
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-extract-put-accepted": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-put-accepted/-/actor-rdf-metadata-extract-put-accepted-2.10.0.tgz",
+      "integrity": "sha512-cGJg6tMMCOSGcitkUBN7b9/Sg5zgwWQC52g+Zk22o4i+Zgt24WLjfXXbnGWGoV+h9YZo8pkg7v1cpE5GpapNCg==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-extract": "^2.10.0",
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-extract-request-time": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-request-time/-/actor-rdf-metadata-extract-request-time-2.10.0.tgz",
+      "integrity": "sha512-zh3coTPZMbgF4mXKCO3bzn99INt9HFraKMZWc9s/kwBE6vhNZ5246Ql/6z1v7mccoIbanhI72gtjFTGGHru80Q==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-extract": "^2.10.0",
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-extract-sparql-service": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-sparql-service/-/actor-rdf-metadata-extract-sparql-service-2.10.0.tgz",
+      "integrity": "sha512-Xc+id8FURTmY3ccb4hcVuAaOou5UqD+1YkTnGfMWQxVgMlFC1eeBvwWVzvedj0sHhnfbLgDwbCVYLCK1lNndSg==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-extract": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "relative-to-absolute-iri": "^1.0.7"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-primary-topic": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-primary-topic/-/actor-rdf-metadata-primary-topic-2.10.0.tgz",
+      "integrity": "sha512-nabxkiYSPGPRylhYjGxF0KiJ/K8QiG1N/am/t8eaqwyjn/fo2/tHl0yXUaLLx0E8fChfbBv10sVlmLhsLrg8DQ==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@rdfjs/types": "*",
+        "readable-stream": "^4.4.2"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-2.10.0.tgz",
+      "integrity": "sha512-zgImXKpc+BN1i6lQiN1Qhlb1HbKdMIeJMOys6qbzRIijdK8GkGGChwhQp7Cso3lY1Nf4K7M3jPLZeQXeED2w7g==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.10.0",
+        "@comunica/bus-rdf-parse-html": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "htmlparser2": "^9.0.0",
+        "readable-stream": "^4.4.2"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-microdata": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-2.10.0.tgz",
+      "integrity": "sha512-JLfiDauq4SmpI6TDS4HaHzI6iJe1j8lSk5FRRYK6YVEu8eO28jPmxQJiOiwbQiYqsjsV7kON/WIZSoUELoI4Ig==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse-html": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "microdata-rdf-streaming-parser": "^2.0.1"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-rdfa": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-2.10.0.tgz",
+      "integrity": "sha512-9K3iaws9+FGl50oZi53hqyzhwjNKZ3mIr2zg/TAJZoapKvc14cthH17zKSSJrqI/NgBStRmZhBBkXcwfu1CANw==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse-html": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "rdfa-streaming-parser": "^2.0.1"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-script": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-2.10.0.tgz",
+      "integrity": "sha512-7XYqWchDquWnBLjG7rmmY+tdE81UZ8fPCU0Hn+vI39/MikNOpaiyr/ZYFqhogWFa9SkjmH0a7idVUzmjiwKRZQ==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.10.0",
+        "@comunica/bus-rdf-parse-html": "^2.10.0",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "readable-stream": "^4.4.2",
+        "relative-to-absolute-iri": "^1.0.7"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-jsonld": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-2.10.0.tgz",
+      "integrity": "sha512-A6TczotUsFyceQf2Nqp4+99c28ZnfkCqUrm7IXPhYUSA6p+KyMew52dr1nC0H7AJ6hRozqY3ZeOrvTjHOWytNg==",
+      "dependencies": {
+        "@comunica/bus-http": "^2.10.0",
+        "@comunica/bus-rdf-parse": "^2.10.0",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "jsonld-context-parser": "^2.2.2",
+        "jsonld-streaming-parser": "^3.0.1",
+        "stream-to-string": "^1.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-n3": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-2.10.0.tgz",
+      "integrity": "sha512-o1MAbwJxW4Br2WCZdhFoRmAiOP4mfogeQqJ4nqlsOkoMtQ45EvLHsotb3Kqhuk5V+vsTxyK5v/a4zylGtcU7VQ==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "n3": "^1.17.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-rdfxml": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-2.10.0.tgz",
+      "integrity": "sha512-HoJN52shXY3cvYtsS0cpin9KXpW3L7g1leebyCRSqnlnHdJv5D6G0Ep8vyt2xhquKNbOQ7LnP5VhiDiqz73XDg==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "rdfxml-streaming-parser": "^2.2.3"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-shaclc": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-shaclc/-/actor-rdf-parse-shaclc-2.10.0.tgz",
+      "integrity": "sha512-i6tmuZuS+RtDiSXpQc3s/PxtCqwIguo4ANmVB20PK4VWgQgBwoPG7LlNcJ0xmuH/3Bv6C2Agn18PLF6dZX+fKw==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "readable-stream": "^4.4.2",
+        "shaclc-parse": "^1.4.0",
+        "stream-to-string": "^1.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-xml-rdfa": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-2.10.0.tgz",
+      "integrity": "sha512-68r/6B/fEyA1/OYleVuaPq47J+g4xJcJijpdL1wEj7CqjV+Xa+sDWRpNCyLcD/e1Y/g9UQmLz0ZnSpR00PFddA==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "rdfa-streaming-parser": "^2.0.1"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-hypermedia-links-next": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-links-next/-/actor-rdf-resolve-hypermedia-links-next-2.10.0.tgz",
+      "integrity": "sha512-SpW46Tx8ksAxotGK2UEpvGcYjKwxB0x2KnbGmKHvo59embRjcUL/bmq3uHqZe7UwfynR2wDaRzMdVVSQccWSyA==",
+      "dependencies": {
+        "@comunica/bus-rdf-resolve-hypermedia-links": "^2.10.0",
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo/-/actor-rdf-resolve-hypermedia-links-queue-fifo-2.10.0.tgz",
+      "integrity": "sha512-Hh53Ts6z6MxKXhZZxgpXfc1hgNzIX/xbA9mD2Au7ZfAa5V5j8zPaVVKe06sxILQBTPMsFh1idP3vIqRwRXpsvg==",
+      "dependencies": {
+        "@comunica/bus-rdf-resolve-hypermedia-links": "^2.10.0",
+        "@comunica/bus-rdf-resolve-hypermedia-links-queue": "^2.10.0",
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-hypermedia-none": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-none/-/actor-rdf-resolve-hypermedia-none-2.10.0.tgz",
+      "integrity": "sha512-C4sJ0QJetq3QxsRkYstK5YXRYDGkcVTfyBOFUMYj7PbVakapnl8qPZkVL7VPMLVLVOfyBQHTT43Yp6Nl8VvmSA==",
+      "dependencies": {
+        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^2.10.0",
+        "@comunica/bus-rdf-resolve-hypermedia": "^2.10.0",
+        "rdf-store-stream": "^2.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-hypermedia-qpf": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-qpf/-/actor-rdf-resolve-hypermedia-qpf-2.10.0.tgz",
+      "integrity": "sha512-1iP9xD72bxFBLpbfC7Ev0Xoc+0rwusPFdnoYbEtqMHRfiM0h3nNrsSxyzdGJMAZaJeQzmBZIEiwR5pbo9qpmaQ==",
+      "dependencies": {
+        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^2.10.0",
+        "@comunica/bus-dereference-rdf": "^2.10.0",
+        "@comunica/bus-rdf-metadata": "^2.10.0",
+        "@comunica/bus-rdf-metadata-extract": "^2.10.0",
+        "@comunica/bus-rdf-resolve-hypermedia": "^2.10.0",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-string": "^1.6.1",
+        "rdf-terms": "^1.11.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-hypermedia-sparql": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-sparql/-/actor-rdf-resolve-hypermedia-sparql-2.10.1.tgz",
+      "integrity": "sha512-VMmdwzsdOKYrO9ONCDm52UGSv3ouGdJsYnMhekPHnu9+nB4j9dpaIQlLehc633339Q4NQZJ6pHQsnH24DeOXFw==",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.10.1",
+        "@comunica/bus-http": "^2.10.0",
+        "@comunica/bus-rdf-resolve-hypermedia": "^2.10.0",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "fetch-sparql-endpoint": "^4.0.0",
+        "lru-cache": "^10.0.0",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-terms": "^1.11.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-hypermedia-sparql/node_modules/lru-cache": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
+      "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-quad-pattern-federated": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-federated/-/actor-rdf-resolve-quad-pattern-federated-2.10.1.tgz",
+      "integrity": "sha512-OBRTTUWkXKa0ibDzcYLG7aKf3BfQp2j75xm65brRvwstNLmye9ZEq1PrNhbP5UDqQQeCgzPBrb0eGC8Vxek2RA==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-rdf-metadata-accumulate": "^2.10.0",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.10.0",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/data-factory": "^2.7.0",
+        "@comunica/metadata": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-terms": "^1.11.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-quad-pattern-hypermedia": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-hypermedia/-/actor-rdf-resolve-quad-pattern-hypermedia-2.10.1.tgz",
+      "integrity": "sha512-XkJOYu0bizWHsvgiaGyNAnRZsqv2risREK5SY14VCMXDYqmOWJLDppveGEUZAoEKEJuo4ZLDlP2gLDGzc0krxQ==",
+      "dependencies": {
+        "@comunica/bus-dereference-rdf": "^2.10.0",
+        "@comunica/bus-http-invalidate": "^2.10.0",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-rdf-metadata": "^2.10.0",
+        "@comunica/bus-rdf-metadata-accumulate": "^2.10.0",
+        "@comunica/bus-rdf-metadata-extract": "^2.10.0",
+        "@comunica/bus-rdf-resolve-hypermedia": "^2.10.0",
+        "@comunica/bus-rdf-resolve-hypermedia-links": "^2.10.0",
+        "@comunica/bus-rdf-resolve-hypermedia-links-queue": "^2.10.0",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.10.0",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/metadata": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "lru-cache": "^10.0.0",
+        "rdf-data-factory": "^1.1.2",
+        "rdf-streaming-store": "^1.1.0",
+        "readable-stream": "^4.4.2",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-quad-pattern-hypermedia/node_modules/lru-cache": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
+      "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source/-/actor-rdf-resolve-quad-pattern-rdfjs-source-2.10.0.tgz",
+      "integrity": "sha512-d6AlrngvZaVgoiiyMhkf6uiYaFZZdn/UZLo0FhZ++or1NZXo5KxK4UMgdiIygvPEiuuVzy0W1djHgOQ1rgh50g==",
+      "dependencies": {
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/metadata": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "rdf-data-factory": "^1.1.2",
+        "rdf-terms": "^1.11.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-quad-pattern-string-source": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-string-source/-/actor-rdf-resolve-quad-pattern-string-source-2.10.0.tgz",
+      "integrity": "sha512-v6QOBtXTXrDUZRHocrm2OYCsxGpyTScka/n85cewCcInqVGJP9J6zpdwetzvIy7wVJkac7JQabd96OEyDMK3sg==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.10.0",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.10.0",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "lru-cache": "^10.0.0",
+        "rdf-store-stream": "^2.0.0",
+        "readable-stream": "^4.4.2"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-quad-pattern-string-source/node_modules/lru-cache": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
+      "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-serialize-jsonld": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-2.10.0.tgz",
+      "integrity": "sha512-u1M5N7BSrkhS461fV6QXKMh6TnvpoEiSHPru7wJg1kGqR9q3reuQeKLf/U23JDYb1kom8uU3R7aBpDIjgVc49Q==",
+      "dependencies": {
+        "@comunica/bus-rdf-serialize": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "jsonld-streaming-serializer": "^2.1.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-serialize-n3": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-2.10.0.tgz",
+      "integrity": "sha512-CoDktUI3YQuI7UBV+fQOdKl+5XjBx0XTOF9XxEDiNg5nwndEmDvq6C23fSHfkqX3/xDlnsuS/YysHAqXCrYoiA==",
+      "dependencies": {
+        "@comunica/bus-rdf-serialize": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "n3": "^1.17.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-serialize-shaclc": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-shaclc/-/actor-rdf-serialize-shaclc-2.10.0.tgz",
+      "integrity": "sha512-gp4bu4+aPtMk4bavXP27uD9X9bpa2F5u6/JtsaX2qwcqVI0x1tkVQOkm2RkUhafcHNj0Fz6lQ3aXmRIAQvaefg==",
+      "dependencies": {
+        "@comunica/bus-rdf-serialize": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "arrayify-stream": "^2.0.1",
+        "readable-stream": "^4.4.2",
+        "shaclc-write": "^1.4.2"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-update-hypermedia-patch-sparql-update": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-hypermedia-patch-sparql-update/-/actor-rdf-update-hypermedia-patch-sparql-update-2.10.1.tgz",
+      "integrity": "sha512-kiO/v6DExTKQb9zeI9PiDJ902R7Jv3B3+Uo/jk9a/jTKk+0Ex+cQby55eql9+jnq/XBlvOTHbrbB8mT3597hpw==",
+      "dependencies": {
+        "@comunica/bus-http": "^2.10.0",
+        "@comunica/bus-rdf-update-hypermedia": "^2.10.1",
+        "@comunica/bus-rdf-update-quads": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "cross-fetch": "^4.0.0",
+        "rdf-string-ttl": "^1.3.2",
+        "readable-stream": "^4.4.2"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-update-hypermedia-patch-sparql-update/node_modules/cross-fetch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-update-hypermedia-put-ldp": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-hypermedia-put-ldp/-/actor-rdf-update-hypermedia-put-ldp-2.10.1.tgz",
+      "integrity": "sha512-88D1Ccb3tvaEYzV17TxbvOsiv9gn1ylO1UDT6gq3cBrNLLmfBt+HNS4CQuQTOo6w71dkBoHs5XSTA8KzekK+3w==",
+      "dependencies": {
+        "@comunica/bus-http": "^2.10.0",
+        "@comunica/bus-rdf-serialize": "^2.10.0",
+        "@comunica/bus-rdf-update-hypermedia": "^2.10.1",
+        "@comunica/bus-rdf-update-quads": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "cross-fetch": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-update-hypermedia-put-ldp/node_modules/cross-fetch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-update-hypermedia-sparql": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-hypermedia-sparql/-/actor-rdf-update-hypermedia-sparql-2.10.1.tgz",
+      "integrity": "sha512-nB6as2JtJ2UtWblp7hZwIqnRZbdxIoFRNjQEmfcS7CJNCekoqIwqhAjdQP14NwhQYiaB9++9pgH4fHRRpT+Rew==",
+      "dependencies": {
+        "@comunica/bus-http": "^2.10.0",
+        "@comunica/bus-rdf-update-hypermedia": "^2.10.1",
+        "@comunica/bus-rdf-update-quads": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "fetch-sparql-endpoint": "^4.0.0",
+        "rdf-string-ttl": "^1.3.2",
+        "stream-to-string": "^1.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-update-quads-hypermedia": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-quads-hypermedia/-/actor-rdf-update-quads-hypermedia-2.10.1.tgz",
+      "integrity": "sha512-SlPXPDEtciTjNqDg/VPFfBG+gBhs7G7PhjjEt2R7gX8iO8R+e15JY7yjI7TAkE5+57E1LosGYy9nDihyHHSbnw==",
+      "dependencies": {
+        "@comunica/bus-dereference-rdf": "^2.10.0",
+        "@comunica/bus-http-invalidate": "^2.10.0",
+        "@comunica/bus-rdf-metadata": "^2.10.0",
+        "@comunica/bus-rdf-metadata-extract": "^2.10.0",
+        "@comunica/bus-rdf-update-hypermedia": "^2.10.1",
+        "@comunica/bus-rdf-update-quads": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "lru-cache": "^10.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-update-quads-hypermedia/node_modules/lru-cache": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
+      "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-update-quads-rdfjs-store": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-quads-rdfjs-store/-/actor-rdf-update-quads-rdfjs-store-2.10.1.tgz",
+      "integrity": "sha512-gC/Tgi9sbo9eMDbkdlXUTF+CdqFTS39Lvbj07wycNBRHFUPYoZB5EnADeG8LHDekLYTUegwzAT1s5YFmb7RePw==",
+      "dependencies": {
+        "@comunica/bus-rdf-update-quads": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-string": "^1.6.1"
+      }
+    },
+    "node_modules/@comunica/bindings-factory": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bindings-factory/-/bindings-factory-2.10.1.tgz",
+      "integrity": "sha512-AUD3VWlCYljgk5jfaMejSIL9CiX3aV/cAn314e/dYP/rrnVgachcCwyaD8hKHWTBHDs5rcGxr/iwruBOfsERvQ==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "immutable": "^4.1.0",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-string": "^1.6.1"
+      }
+    },
+    "node_modules/@comunica/bus-context-preprocess": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-context-preprocess/-/bus-context-preprocess-2.10.0.tgz",
+      "integrity": "sha512-eJ5CkzbnmxB9fkr2F05jnnjcaowp+yxd0+pAtvx5MLl2Kpx3nWLqHPcl4/EVVDPD+i0TEkq4AXQ1BD9BMuXK0A==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/bus-dereference": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-dereference/-/bus-dereference-2.10.0.tgz",
+      "integrity": "sha512-nWyQXiH7zbiPTVttWVKJHykhV4IuahfhfUwPx3Op+cVsK489Su84dnGeSmPkxTAFFuxe6wU6ZEH4i7PDu48YvQ==",
+      "dependencies": {
+        "@comunica/actor-abstract-mediatyped": "^2.10.0",
+        "@comunica/actor-abstract-parse": "^2.10.0",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "readable-stream": "^4.4.2"
+      }
+    },
+    "node_modules/@comunica/bus-dereference-rdf": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-dereference-rdf/-/bus-dereference-rdf-2.10.0.tgz",
+      "integrity": "sha512-WY/wPmFpO76wwJ2D5Aus43ZbYnBRLvQ0EOp4yywO0lBiq6F0JisjCVCM4EtWouOEAAfqEoIjHXGyC3gPWqm+SQ==",
+      "dependencies": {
+        "@comunica/bus-dereference": "^2.10.0",
+        "@comunica/bus-rdf-parse": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/bus-hash-bindings": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-hash-bindings/-/bus-hash-bindings-2.10.0.tgz",
+      "integrity": "sha512-EdzIUgpSWMtFVxEJSesuQpMkfgznDap+U0F9epotxXc20Gg/qjTzs1gF6NkpDpaidQ7cFlV16vdbdfi8uiZ+mQ==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/bus-http": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-2.10.0.tgz",
+      "integrity": "sha512-wITLxYFvAuFsml4txgxYfxzgroVtWCi+Ja3TTN1l+MpeN1CyDfcA3oL30W8jLMJStjxt1SUmtuOoUjM1lzsbFA==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "is-stream": "^2.0.1",
+        "readable-stream-node-to-web": "^1.0.1",
+        "readable-web-to-node-stream": "^3.0.2",
+        "web-streams-ponyfill": "^1.4.2"
+      }
+    },
+    "node_modules/@comunica/bus-http-invalidate": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-http-invalidate/-/bus-http-invalidate-2.10.0.tgz",
+      "integrity": "sha512-9DevRUzuCOfHFtsryIvTU6rOz6vMbnuDzerloBoNsLFVzQCU4wPNZbxiOn0+GMDXxw7M3KgYd+KFxI2kGObVWA==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/bus-http/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@comunica/bus-init": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-2.10.0.tgz",
+      "integrity": "sha512-hJejHa8sLVhQLFlduCVnhOd5aW3FCEz8wmWjyeLI3kiHFaQibnGVMhUuuNRX5f8bnnPuTdEiHc1nnYHuSi+j8A==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "readable-stream": "^4.4.2"
+      }
+    },
+    "node_modules/@comunica/bus-optimize-query-operation": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-optimize-query-operation/-/bus-optimize-query-operation-2.10.0.tgz",
+      "integrity": "sha512-qawKJprbVc+dfjBgVzV45UEo+jZBzY3dRo0a8UkXSvgSWPcX18SGrURl2VL4sZZSAyXQBMrGUwH2eUD8l26ZJQ==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/bus-query-operation": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-operation/-/bus-query-operation-2.10.1.tgz",
+      "integrity": "sha512-PoUSJeKaMZtZu+ZtB+5ABjPOiW1YjxOdLE1N5znxX2oiDKCQHmAXVaVkbVx1jPDLGYFNcOlOSzpRMqLQ/L4JIw==",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.10.1",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/data-factory": "^2.7.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "rdf-string": "^1.6.1",
+        "rdf-terms": "^1.11.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/bus-query-parse": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-parse/-/bus-query-parse-2.10.0.tgz",
+      "integrity": "sha512-1LynxACgCYTuBH/JMRG/IGaWtTVwr2O8wxOosCId2W3BDW9nf2DSCyOdnxnCSMSKfnLFWiaVuKybn24OLXW2dQ==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "@rdfjs/types": "*",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/bus-query-result-serialize": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-result-serialize/-/bus-query-result-serialize-2.10.0.tgz",
+      "integrity": "sha512-9P5KUzmXvjtLbd44UVxYNB0yqAHx7molBUc7aysUQ3pbIcP/A57GXzAfiKueeiZ9cVRRG/BGsVoDGVj59tGWNg==",
+      "dependencies": {
+        "@comunica/actor-abstract-mediatyped": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-join": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join/-/bus-rdf-join-2.10.1.tgz",
+      "integrity": "sha512-pPFoJVHY5p931jIKt+9sqRCGiuuf8yFqrlOOAd3un72cwuyhwNHvn52xwvcPlNUAySz/kDmW+U0syflqI6VdAw==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-rdf-join-selectivity": "^2.10.0",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/mediatortype-join-coefficients": "^2.10.0",
+        "@comunica/metadata": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-string": "^1.6.1"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-join-entries-sort": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join-entries-sort/-/bus-rdf-join-entries-sort-2.10.0.tgz",
+      "integrity": "sha512-17FQrdYtzjY84OI/ZvipJKD0ei3IySmsWwaGC9sIJn+1W4LBVKudTu5S0tzGTKTb0URhS4mrCliUBzyINtIZMQ==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-join-selectivity": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join-selectivity/-/bus-rdf-join-selectivity-2.10.0.tgz",
+      "integrity": "sha512-YjoygSiH6r4SAYqz6gpvUql2vnznPVE62IsWqYnjFWeH1kBsxO5yEOO01s2FfN3jLcfsytTyG7VNTCN788YbaA==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "@comunica/mediatortype-accuracy": "^2.10.0",
+        "@comunica/types": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-metadata": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata/-/bus-rdf-metadata-2.10.0.tgz",
+      "integrity": "sha512-LRUnHVqIzyUlmPKPNAYOusCF53iN8KEX7l/VinlA7NH3XBLhTkFoth26MVqIVtjtdH0hVfUVpkwy2kFEJpGldw==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-metadata-accumulate": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-accumulate/-/bus-rdf-metadata-accumulate-2.10.0.tgz",
+      "integrity": "sha512-XG/3s4a3yGpYt4H+sn9T2zTaUxLG+37dmhRhXv2cBmR4gaCXkglERPaOrQygHldEF+4ITF3RmXHCgANsQ1AwQg==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-metadata-extract": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-extract/-/bus-rdf-metadata-extract-2.10.0.tgz",
+      "integrity": "sha512-KcMZh+7kHjdCIMkLFki99tQH1arVp/evVnk0BGXfWd+ca3eCLrr42tb1tGfN2JkaCSxgtzWO4DRZcSzJ4sI2dQ==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-parse": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-2.10.0.tgz",
+      "integrity": "sha512-EgCMZACfTG/+mayQpExWt0HoBT32BBVC1aS1lC43fXKBTxJ8kYrSrorVUuMACoh4dQVGTb+7j1j4K0hGNVzXGA==",
+      "dependencies": {
+        "@comunica/actor-abstract-mediatyped": "^2.10.0",
+        "@comunica/actor-abstract-parse": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-parse-html": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-2.10.0.tgz",
+      "integrity": "sha512-RZliz4TtKP63QggoohGuIkGb6lq0BoYJ4aztKtGldWtPAVP/pdEvlDpiZWLB/j19g7S2aDLNY/lJtZ5efM1tHQ==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-resolve-hypermedia": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia/-/bus-rdf-resolve-hypermedia-2.10.0.tgz",
+      "integrity": "sha512-DjCoAg62pPzEOH5gKM9gaL4CVUmhBsmyOzao0tRu20G7L6RnTIFtRaOwMN2z+2uC7AkJRHZY12bPUb+yM8V0UQ==",
+      "dependencies": {
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-resolve-hypermedia-links": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia-links/-/bus-rdf-resolve-hypermedia-links-2.10.0.tgz",
+      "integrity": "sha512-Mcz6bUdZySLK2om0cMt86n5TOThZOTpEFq2M42n7YAE3LL2KMnMDdhkaOC6SyY4tS0HGAuhce21Uq+Gz8Veq2g==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-resolve-hypermedia-links-queue": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia-links-queue/-/bus-rdf-resolve-hypermedia-links-queue-2.10.0.tgz",
+      "integrity": "sha512-f9amJk7ikktRfOoRnwag1KMTuo9v+PiDEVQA0dijl+jhcispKdjG6XK0MdZ1KSEmtUWejjS6nMRGvfJdM37eog==",
+      "dependencies": {
+        "@comunica/bus-rdf-resolve-hypermedia-links": "^2.10.0",
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-resolve-quad-pattern": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-quad-pattern/-/bus-rdf-resolve-quad-pattern-2.10.0.tgz",
+      "integrity": "sha512-JEI4DqSprGmrbfmiIwc8PbS+HCoxXwmMtp7gDpoB1HyYKIHzzu9DOIiwmYEDRO5dwV+uTwaYKZz/mUPm2U6EEg==",
+      "dependencies": {
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-serialize": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-2.10.0.tgz",
+      "integrity": "sha512-AmbN9MUgw6B6AfrIqR1u7PWHZFgbJz+j1SFJVtnHQ51hEpG+Ig9nNG2IWjHOsFK0xBBQ/wXgNmt/cufEMRM1SQ==",
+      "dependencies": {
+        "@comunica/actor-abstract-mediatyped": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-update-hypermedia": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-update-hypermedia/-/bus-rdf-update-hypermedia-2.10.1.tgz",
+      "integrity": "sha512-egj4G0zzUI3oZ1iJaAxKX1wic0fZ0Iesa02gOTf94lhVjo+SYL+KJ1mopem1FSsY8eMf5IhkMwQnmxQT2xzSXw==",
+      "dependencies": {
+        "@comunica/bus-rdf-update-quads": "^2.10.1",
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-update-quads": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-update-quads/-/bus-rdf-update-quads-2.10.1.tgz",
+      "integrity": "sha512-DuAgGsdMbZj7TRALB1uPwEuwZcfdVHMWO2WOJJ0ptZ9ACfKGoe2hHrrE0OeNnfI+1zwq/nIoefKtEgg2Jj7u0g==",
+      "dependencies": {
+        "@comunica/actor-rdf-resolve-quad-pattern-federated": "^2.10.1",
+        "@comunica/bus-http": "^2.10.0",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "stream-to-string": "^1.2.0"
+      }
+    },
+    "node_modules/@comunica/config-query-sparql": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@comunica/config-query-sparql/-/config-query-sparql-2.7.0.tgz",
+      "integrity": "sha512-rMnFgT7cz9+0z7wV4OzIMY5qM9/Z0mTGrR8y2JokoHyyTcBGOSajFmy61XCSLMCsLLG8qDXsJ4ClCCky3TGfqA=="
+    },
+    "node_modules/@comunica/context-entries": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/context-entries/-/context-entries-2.10.0.tgz",
+      "integrity": "sha512-lmCYCcXxW8C6ecFH2whZCt31NT1ejb0P/sbytK7f4ctyA06Q8iYFEcYE4eWOXMdpfkwkcnz31x9XL77OGeSC2Q==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "jsonld-context-parser": "^2.2.2",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/core": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-onsGs2iKHUPRxxMOdx42vdxslk8q9FQZdRjQtHJ6SGiCpJwIL9ciBgPIOl2RL2YfzXHemr/0umeNOppRDcWhJA==",
+      "dependencies": {
+        "@comunica/types": "^2.10.0",
+        "immutable": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/@comunica/data-factory": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@comunica/data-factory/-/data-factory-2.7.0.tgz",
+      "integrity": "sha512-dSTzrR1w9SzAWx70ZXKXHUC8f0leUolLZ9TOhGjFhhsBMJ9Pbo0g6vHV8txX5FViShngrg9QNKhsHeQnMk5z6Q==",
+      "dependencies": {
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/expression-evaluator": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/expression-evaluator/-/expression-evaluator-2.10.0.tgz",
+      "integrity": "sha512-gSfiVSAE+SaxpXq3jT5OnyZd+sD9KFaWtTiKT1tDDs8lD7Jj68aRP7VoEhvKwPwRlUx0aoaXUL2MYtV6JsXRbg==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/spark-md5": "^3.0.2",
+        "@types/uuid": "^9.0.0",
+        "bignumber.js": "^9.0.1",
+        "hash.js": "^1.1.7",
+        "lru-cache": "^10.0.0",
+        "rdf-data-factory": "^1.1.2",
+        "rdf-string": "^1.6.3",
+        "relative-to-absolute-iri": "^1.0.6",
+        "spark-md5": "^3.0.1",
+        "sparqlalgebrajs": "^4.2.0",
+        "uuid": "^9.0.0"
+      }
+    },
+    "node_modules/@comunica/expression-evaluator/node_modules/lru-cache": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
+      "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/@comunica/expression-evaluator/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@comunica/logger-pretty": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/logger-pretty/-/logger-pretty-2.10.0.tgz",
+      "integrity": "sha512-JXkeM5HnbyTPnQTf5/ugRPL9R+vXT7b/hRVYzYmhAGCjkCNL7NJPTBbIgxmZHqZ+UGxprotrvmDQtwHmVA+Ddw==",
+      "dependencies": {
+        "@comunica/types": "^2.10.0",
+        "object-inspect": "^1.12.2",
+        "process": "^0.11.10"
+      }
+    },
+    "node_modules/@comunica/logger-void": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/logger-void/-/logger-void-2.10.0.tgz",
+      "integrity": "sha512-GFJh9hV8rIC9yXAuLGGKjQRVs8IOQOINBbaTNO+FJUWWWHlo5pDEKAoGYuysz5TBGoT3Lexz8bMfdkuHMa3uIQ==",
+      "dependencies": {
+        "@comunica/types": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/mediator-all": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-all/-/mediator-all-2.10.0.tgz",
+      "integrity": "sha512-y1+A+sIW462G8iPzi6BSPIb4I9iy08ZruM2Thf1or6sytwLKro7E2RYjS6IdupwfFYafXXCeT85+lrJgTKERhQ==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/mediator-combine-pipeline": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-2.10.0.tgz",
+      "integrity": "sha512-j7+/oUlbhKB4Rq6g9oNKU+e9cQL8U9z8tAUNhoXUSHajcr4huj0t1+riaOD109/DRWhV793ILhBDzgiZbHd7DA==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/mediator-combine-union": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-2.10.0.tgz",
+      "integrity": "sha512-QbP4zP1i6nMDZ8teC0RoTz5E8pOpxDhWPBr1ylb2jzPUjPpMgrnbHYTondlN0Oau3SMEehItojg/LYDtPOP/GQ==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/mediator-join-coefficients-fixed": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-join-coefficients-fixed/-/mediator-join-coefficients-fixed-2.10.1.tgz",
+      "integrity": "sha512-HRvc0e8QDnR3sbRMMCyx9ILFA6KiUxHEqDOpt7BV3kFMWWIpBavFDwPUjLBG6sRA8o0CFu1+oVVh5fAFYZIxzQ==",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^2.10.1",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/mediatortype-join-coefficients": "^2.10.0",
+        "@comunica/types": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/mediator-number": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-2.10.0.tgz",
+      "integrity": "sha512-0T8D1HGTu5Sd8iKb2dBjc6VRc/U4A15TAN6m561ra9pFlP+w31kby0ZYP6WWBHBobbUsX1LCvnbRQaAC4uWwVw==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/mediator-race": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-2.10.0.tgz",
+      "integrity": "sha512-JiEtOLMkPnbjSLabVpE4VqDbu2ZKKnkUdATGBeWX+o+MjPw6c0hhw01RG4WY2rQhDyNl++nLQe3EowQh8xW9TA==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/mediatortype-accuracy": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-accuracy/-/mediatortype-accuracy-2.10.0.tgz",
+      "integrity": "sha512-u9Noai4yGACaBRGOoRZ65XoQhazKNx5QaFOX5nJ/p84Qq4g50woC2rpsncuyrXhW1j/rIc2WvIUGUfy/g6CDiw==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/mediatortype-httprequests": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-httprequests/-/mediatortype-httprequests-2.10.0.tgz",
+      "integrity": "sha512-uPjs/NdngHZZWomjZor6W29UeOlxganupIOa3Z6H3qdUnsSpxeoS9URXy7BICAX+4PmgebperSn18BRA+PWiSw==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/mediatortype-join-coefficients": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-join-coefficients/-/mediatortype-join-coefficients-2.10.0.tgz",
+      "integrity": "sha512-EPipAV5PDNeEVXbsd+8NsqNKu5ztCAoEJ3azcFAmD9di9ppArNJWU/mxy5yUzcBgMUX4wRp6jCa5rIF5sRHG7g==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/mediatortype-time": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-time/-/mediatortype-time-2.10.0.tgz",
+      "integrity": "sha512-nBz1exxrja1Tj8KSlSevG4Hw2u09tTh6gtNfVjI76i/e7muu4RUWVhi9b8PcwBNAfuUqRl+5OgOSa2X4W+6QlA==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/metadata": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/metadata/-/metadata-2.10.0.tgz",
+      "integrity": "sha512-PF7TKhuDIO4GE9tzuAkTxarQV5cmwXZ64hp0qm8Ql/V+dVHu/3xLL9v/Q67ZX26GF9hOyr7cdpNI08M7DHc86g==",
+      "dependencies": {
+        "@comunica/types": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/query-sparql": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/query-sparql/-/query-sparql-2.10.1.tgz",
+      "integrity": "sha512-kdETEOGUVyk33giosSiwlUNxPq6onsVtOpTyPTyCOmgZqt/c0bDwSIF3JkXUFGlu8Yvn2uTfr7+16cUf9JwX2g==",
+      "dependencies": {
+        "@comunica/actor-context-preprocess-source-to-destination": "^2.10.0",
+        "@comunica/actor-dereference-fallback": "^2.10.0",
+        "@comunica/actor-dereference-http": "^2.10.0",
+        "@comunica/actor-dereference-rdf-parse": "^2.10.0",
+        "@comunica/actor-hash-bindings-sha1": "^2.10.0",
+        "@comunica/actor-http-fetch": "^2.10.1",
+        "@comunica/actor-http-proxy": "^2.10.0",
+        "@comunica/actor-http-wayback": "^2.10.0",
+        "@comunica/actor-init-query": "^2.10.1",
+        "@comunica/actor-optimize-query-operation-bgp-to-join": "^2.10.0",
+        "@comunica/actor-optimize-query-operation-join-bgp": "^2.10.0",
+        "@comunica/actor-optimize-query-operation-join-connected": "^2.10.0",
+        "@comunica/actor-query-operation-ask": "^2.10.1",
+        "@comunica/actor-query-operation-bgp-join": "^2.10.1",
+        "@comunica/actor-query-operation-construct": "^2.10.1",
+        "@comunica/actor-query-operation-describe-subject": "^2.10.1",
+        "@comunica/actor-query-operation-distinct-hash": "^2.10.1",
+        "@comunica/actor-query-operation-extend": "^2.10.1",
+        "@comunica/actor-query-operation-filter-sparqlee": "^2.10.1",
+        "@comunica/actor-query-operation-from-quad": "^2.10.1",
+        "@comunica/actor-query-operation-group": "^2.10.1",
+        "@comunica/actor-query-operation-join": "^2.10.1",
+        "@comunica/actor-query-operation-leftjoin": "^2.10.1",
+        "@comunica/actor-query-operation-minus": "^2.10.1",
+        "@comunica/actor-query-operation-nop": "^2.10.1",
+        "@comunica/actor-query-operation-orderby-sparqlee": "^2.10.1",
+        "@comunica/actor-query-operation-path-alt": "^2.10.1",
+        "@comunica/actor-query-operation-path-inv": "^2.10.1",
+        "@comunica/actor-query-operation-path-link": "^2.10.1",
+        "@comunica/actor-query-operation-path-nps": "^2.10.1",
+        "@comunica/actor-query-operation-path-one-or-more": "^2.10.1",
+        "@comunica/actor-query-operation-path-seq": "^2.10.1",
+        "@comunica/actor-query-operation-path-zero-or-more": "^2.10.1",
+        "@comunica/actor-query-operation-path-zero-or-one": "^2.10.1",
+        "@comunica/actor-query-operation-project": "^2.10.1",
+        "@comunica/actor-query-operation-quadpattern": "^2.10.1",
+        "@comunica/actor-query-operation-reduced-hash": "^2.10.1",
+        "@comunica/actor-query-operation-service": "^2.10.1",
+        "@comunica/actor-query-operation-slice": "^2.10.1",
+        "@comunica/actor-query-operation-sparql-endpoint": "^2.10.1",
+        "@comunica/actor-query-operation-union": "^2.10.1",
+        "@comunica/actor-query-operation-update-add-rewrite": "^2.10.1",
+        "@comunica/actor-query-operation-update-clear": "^2.10.1",
+        "@comunica/actor-query-operation-update-compositeupdate": "^2.10.1",
+        "@comunica/actor-query-operation-update-copy-rewrite": "^2.10.1",
+        "@comunica/actor-query-operation-update-create": "^2.10.1",
+        "@comunica/actor-query-operation-update-deleteinsert": "^2.10.1",
+        "@comunica/actor-query-operation-update-drop": "^2.10.1",
+        "@comunica/actor-query-operation-update-load": "^2.10.1",
+        "@comunica/actor-query-operation-update-move-rewrite": "^2.10.1",
+        "@comunica/actor-query-operation-values": "^2.10.1",
+        "@comunica/actor-query-parse-graphql": "^2.10.0",
+        "@comunica/actor-query-parse-sparql": "^2.10.0",
+        "@comunica/actor-query-result-serialize-json": "^2.10.0",
+        "@comunica/actor-query-result-serialize-rdf": "^2.10.0",
+        "@comunica/actor-query-result-serialize-simple": "^2.10.0",
+        "@comunica/actor-query-result-serialize-sparql-csv": "^2.10.0",
+        "@comunica/actor-query-result-serialize-sparql-json": "^2.10.0",
+        "@comunica/actor-query-result-serialize-sparql-tsv": "^2.10.0",
+        "@comunica/actor-query-result-serialize-sparql-xml": "^2.10.0",
+        "@comunica/actor-query-result-serialize-stats": "^2.10.0",
+        "@comunica/actor-query-result-serialize-table": "^2.10.0",
+        "@comunica/actor-query-result-serialize-tree": "^2.10.0",
+        "@comunica/actor-rdf-join-entries-sort-cardinality": "^2.10.0",
+        "@comunica/actor-rdf-join-inner-hash": "^2.10.1",
+        "@comunica/actor-rdf-join-inner-multi-bind": "^2.10.1",
+        "@comunica/actor-rdf-join-inner-multi-empty": "^2.10.1",
+        "@comunica/actor-rdf-join-inner-multi-smallest": "^2.10.1",
+        "@comunica/actor-rdf-join-inner-nestedloop": "^2.10.1",
+        "@comunica/actor-rdf-join-inner-none": "^2.10.1",
+        "@comunica/actor-rdf-join-inner-single": "^2.10.1",
+        "@comunica/actor-rdf-join-inner-symmetrichash": "^2.10.1",
+        "@comunica/actor-rdf-join-minus-hash": "^2.10.1",
+        "@comunica/actor-rdf-join-minus-hash-undef": "^2.10.1",
+        "@comunica/actor-rdf-join-optional-bind": "^2.10.1",
+        "@comunica/actor-rdf-join-optional-nestedloop": "^2.10.1",
+        "@comunica/actor-rdf-join-selectivity-variable-counting": "^2.10.0",
+        "@comunica/actor-rdf-metadata-accumulate-cancontainundefs": "^2.10.0",
+        "@comunica/actor-rdf-metadata-accumulate-cardinality": "^2.10.0",
+        "@comunica/actor-rdf-metadata-accumulate-pagesize": "^2.10.0",
+        "@comunica/actor-rdf-metadata-accumulate-requesttime": "^2.10.0",
+        "@comunica/actor-rdf-metadata-all": "^2.10.0",
+        "@comunica/actor-rdf-metadata-extract-allow-http-methods": "^2.10.0",
+        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^2.10.0",
+        "@comunica/actor-rdf-metadata-extract-hydra-count": "^2.10.0",
+        "@comunica/actor-rdf-metadata-extract-hydra-pagesize": "^2.10.0",
+        "@comunica/actor-rdf-metadata-extract-patch-sparql-update": "^2.10.0",
+        "@comunica/actor-rdf-metadata-extract-put-accepted": "^2.10.0",
+        "@comunica/actor-rdf-metadata-extract-request-time": "^2.10.0",
+        "@comunica/actor-rdf-metadata-extract-sparql-service": "^2.10.0",
+        "@comunica/actor-rdf-metadata-primary-topic": "^2.10.0",
+        "@comunica/actor-rdf-parse-html": "^2.10.0",
+        "@comunica/actor-rdf-parse-html-microdata": "^2.10.0",
+        "@comunica/actor-rdf-parse-html-rdfa": "^2.10.0",
+        "@comunica/actor-rdf-parse-html-script": "^2.10.0",
+        "@comunica/actor-rdf-parse-jsonld": "^2.10.0",
+        "@comunica/actor-rdf-parse-n3": "^2.10.0",
+        "@comunica/actor-rdf-parse-rdfxml": "^2.10.0",
+        "@comunica/actor-rdf-parse-shaclc": "^2.10.0",
+        "@comunica/actor-rdf-parse-xml-rdfa": "^2.10.0",
+        "@comunica/actor-rdf-resolve-hypermedia-links-next": "^2.10.0",
+        "@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": "^2.10.0",
+        "@comunica/actor-rdf-resolve-hypermedia-none": "^2.10.0",
+        "@comunica/actor-rdf-resolve-hypermedia-qpf": "^2.10.0",
+        "@comunica/actor-rdf-resolve-hypermedia-sparql": "^2.10.1",
+        "@comunica/actor-rdf-resolve-quad-pattern-federated": "^2.10.1",
+        "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": "^2.10.1",
+        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^2.10.0",
+        "@comunica/actor-rdf-resolve-quad-pattern-string-source": "^2.10.0",
+        "@comunica/actor-rdf-serialize-jsonld": "^2.10.0",
+        "@comunica/actor-rdf-serialize-n3": "^2.10.0",
+        "@comunica/actor-rdf-serialize-shaclc": "^2.10.0",
+        "@comunica/actor-rdf-update-hypermedia-patch-sparql-update": "^2.10.1",
+        "@comunica/actor-rdf-update-hypermedia-put-ldp": "^2.10.1",
+        "@comunica/actor-rdf-update-hypermedia-sparql": "^2.10.1",
+        "@comunica/actor-rdf-update-quads-hypermedia": "^2.10.1",
+        "@comunica/actor-rdf-update-quads-rdfjs-store": "^2.10.1",
+        "@comunica/bus-http-invalidate": "^2.10.0",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/config-query-sparql": "^2.7.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/logger-void": "^2.10.0",
+        "@comunica/mediator-all": "^2.10.0",
+        "@comunica/mediator-combine-pipeline": "^2.10.0",
+        "@comunica/mediator-combine-union": "^2.10.0",
+        "@comunica/mediator-join-coefficients-fixed": "^2.10.1",
+        "@comunica/mediator-number": "^2.10.0",
+        "@comunica/mediator-race": "^2.10.0",
+        "@comunica/runner": "^2.10.0",
+        "@comunica/runner-cli": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "process": "^0.11.10"
+      },
+      "bin": {
+        "comunica-dynamic-sparql": "bin/query-dynamic.js",
+        "comunica-sparql": "bin/query.js",
+        "comunica-sparql-http": "bin/http.js"
+      }
+    },
+    "node_modules/@comunica/runner": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/runner/-/runner-2.10.0.tgz",
+      "integrity": "sha512-v/oEKT+IwjO6Y74bCCzlR+ZMI6oykpfz7GQrQbl1oTWQsvBbTdf0omPkoYnk1esEAsFnsJD+NGwAiRiFKeBo0A==",
+      "dependencies": {
+        "@comunica/bus-init": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "componentsjs": "^5.3.2",
+        "process": "^0.11.10"
+      },
+      "bin": {
+        "comunica-compile-config": "bin/compile-config"
+      }
+    },
+    "node_modules/@comunica/runner-cli": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/runner-cli/-/runner-cli-2.10.0.tgz",
+      "integrity": "sha512-16QI0rWFHURCy5waVFcZ/fhKI/hyzNx5YyCGPaEaUX8MKyamvCCXHSWvPLLbjJbsjGZ9wXrC9dwwhRmbfmidpw==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "@comunica/runner": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "process": "^0.11.10"
+      },
+      "bin": {
+        "comunica-run": "bin/run.js"
+      }
+    },
+    "node_modules/@comunica/types": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-2.10.0.tgz",
+      "integrity": "sha512-1UjPGbZcYrapBjMGUZedrIGcn9rOLpEOlJo1ZkWddFUGTwndVg9d4BZnQw+UnQzXMcLJcdKt94Zns8iEmBqARw==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/yargs": "^17.0.24",
+        "asynciterator": "^3.8.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
+      "integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
+      "dependencies": {
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
       }
     },
     "node_modules/@digitalbazaar/http-client": {
@@ -200,6 +2504,17 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
       "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw=="
     },
+    "node_modules/@jeswr/prefixcc": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jeswr/prefixcc/-/prefixcc-1.2.1.tgz",
+      "integrity": "sha512-kBBXbqsaeh3Irp416h/RbelqJgIOp6X/OJJlYmLyr/9qlBYKTKSCuEv5/xjZ0Yf8Yec+QFRYBaOQ2JkMBSH7KA==",
+      "dependencies": {
+        "cross-fetch": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -252,6 +2567,33 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/@rdfjs/types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.0.tgz",
+      "integrity": "sha512-5zm8bN2/CC634dTcn/0AhTRLaQRjXDZs3QfcAsQKNturHT7XVWcKy/8p3P5gXl+YkZTAmy7T5M/LyiT/jbkENw==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@rubensworks/saxes": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@rubensworks/saxes/-/saxes-6.0.1.tgz",
+      "integrity": "sha512-UW4OTIsOtJ5KSXo2Tchi4lhZqu+tlHrOAs4nNti7CrtB53kAZl3/hyrTi6HkMihxdbDM6m2Zc3swc/ZewEe1xw==",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.12"
+      }
+    },
+    "node_modules/@types/http-link-header": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-link-header/-/http-link-header-1.0.5.tgz",
+      "integrity": "sha512-AxhIKR8UbyoqCTNp9rRepkktHuUOw3DjfOfDCaO9kwI8AYzjhxyrvZq4+mRw/2daD3hYDknrtSeV6SsPwmc71w==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -263,11 +2605,87 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
     },
+    "node_modules/@types/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag=="
+    },
+    "node_modules/@types/n3": {
+      "version": "1.16.4",
+      "resolved": "https://registry.npmjs.org/@types/n3/-/n3-1.16.4.tgz",
+      "integrity": "sha512-6PmHRYCCdjbbBV2UVC/HjtL6/5Orx9ku2CQjuojucuHvNvPmnm6+02B18YGhHfvU25qmX2jPXyYPHsMNkn+w2w==",
+      "dependencies": {
+        "@rdfjs/types": "^1.1.0",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.10.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.4.tgz",
+      "integrity": "sha512-D08YG6rr8X90YB56tSIuBaddy/UXAA9RKJoFvrsnogAum/0pmjkgi4+2nx96A330FmioegBWmEYQ+syqCFaveg==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/readable-stream": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.15.tgz",
+      "integrity": "sha512-oM5JSKQCcICF1wvGgmecmHldZ48OZamtMxcGGVICOJA8o8cahXC1zEVAif8iwoc5j8etxFaRFnf095+CDsuoFQ==",
+      "dependencies": {
+        "@types/node": "*",
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "node_modules/@types/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
     "node_modules/@types/semver": {
       "version": "7.5.6",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
-      "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
-      "dev": true
+      "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A=="
+    },
+    "node_modules/@types/spark-md5": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/spark-md5/-/spark-md5-3.0.4.tgz",
+      "integrity": "sha512-qtOaDz+IXiNndPgYb6t1YoutnGvFRtWSNzpVjkAPCfB2UzTyybuD4Tjgs7VgRawum3JnJNRwNQd4N//SvrHg1Q=="
+    },
+    "node_modules/@types/sparqljs": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@types/sparqljs/-/sparqljs-3.1.9.tgz",
+      "integrity": "sha512-ApqCSKmXhSm1YocgDgFDRM6W4d9+UkAQHNmUTAk2VHZSLzR41wMf84hWo/4CFFVRuyRGYZxgPJdLuwOj4fNlSA==",
+      "dependencies": {
+        "rdf-js": "^4.0.2"
+      }
+    },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
+    },
+    "node_modules/@types/uritemplate": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@types/uritemplate/-/uritemplate-0.3.6.tgz",
+      "integrity": "sha512-31BMGZ8GgLxgXxLnqg4KbbyYJjU1flhTTD2+PVQStVUPXSk0IIpK0zt+tH3eLT7ZRwLnzQw6JhYx69qza3U0wg=="
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.7.tgz",
+      "integrity": "sha512-WUtIVRUZ9i5dYXefDEAI7sh9/O7jGvHg7Df/5O/gtH3Yabe5odI3UWopVR1qbPXQtvOxWu3mM4XxlYeZtMWF4g=="
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.32",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
+      "integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "6.13.2",
@@ -806,12 +3224,35 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/arrayify-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrayify-stream/-/arrayify-stream-2.0.1.tgz",
+      "integrity": "sha512-z8fB6PtmnewQpFB53piS2d1KlUi3BPMICH2h7leCOUXpQcwvZ4GbHHSpdKoUrgLMR6b4Qan/uDe1St3Ao3yIHg=="
+    },
+    "node_modules/async": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
+    },
+    "node_modules/asynciterator": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/asynciterator/-/asynciterator-3.8.1.tgz",
+      "integrity": "sha512-SmdG0FUY3pYGOZZGdYq8Qb/DCRDXBFZUk08V1/4lbBXdAQvcC3Kxzz9FUDPBTik7VAVltt4cZirAPtJv3gOpEw=="
+    },
     "node_modules/asynciterator.prototype": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/asynciterator.prototype/-/asynciterator.prototype-1.0.0.tgz",
       "integrity": "sha512-wwHYEIS0Q80f5mosx3L/dfG5t5rjEa9Ft51GTaNt862EnpyGHpgz2RkZvLPp1oF5TnAiTohkEKVEu8pQPJI7Vg==",
       "dependencies": {
         "has-symbols": "^1.0.3"
+      }
+    },
+    "node_modules/asyncjoin": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/asyncjoin/-/asyncjoin-1.1.2.tgz",
+      "integrity": "sha512-zi6B+C3GgEu8qrmFn3gDd58cbGNaNFW3s8DJmCxUOjQwqWZcQO6dEoZBWl56+QGQyX0da0FRX1fsAyYB9LmwJA==",
+      "dependencies": {
+        "asynciterator": "^3.6.0"
       }
     },
     "node_modules/at-least-node": {
@@ -864,6 +3305,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/body-parser": {
@@ -1031,6 +3480,28 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "dependencies": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1046,6 +3517,86 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+    },
+    "node_modules/colorspace": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
+      "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
+      "dependencies": {
+        "color": "^3.1.3",
+        "text-hex": "1.0.x"
+      }
+    },
+    "node_modules/componentsjs": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/componentsjs/-/componentsjs-5.4.2.tgz",
+      "integrity": "sha512-qIeXLozDkvubl6qtiovWsIBRqUP80w1ImTbilB6QE3OQgaEExI8pYZ9MkZ10QDFtdoKUryztlqp0AWs49t4puA==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/minimist": "^1.2.0",
+        "@types/node": "^18.0.0",
+        "@types/semver": "^7.3.4",
+        "jsonld-context-parser": "^2.1.1",
+        "minimist": "^1.2.0",
+        "rdf-data-factory": "^1.1.0",
+        "rdf-object": "^1.14.0",
+        "rdf-parse": "^2.0.0",
+        "rdf-quad": "^1.5.0",
+        "rdf-string": "^1.6.0",
+        "rdf-terms": "^1.7.0",
+        "semver": "^7.3.2",
+        "winston": "^3.3.3"
+      },
+      "bin": {
+        "componentsjs-compile-config": "bin/compile-config.js"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/componentsjs/node_modules/@types/node": {
+      "version": "18.19.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.3.tgz",
+      "integrity": "sha512-k5fggr14DwAytoA/t8rPrIz++lXK7/DqckthCmoZOKNsEbJkId4Z//BqgApXBUGrGddrigYa1oqheo/7YmW4rg==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/componentsjs/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -1230,10 +3781,82 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -1351,6 +3974,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -1983,6 +4614,11 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
+    },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
@@ -2003,6 +4639,41 @@
       },
       "engines": {
         "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/fetch-sparql-endpoint": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/fetch-sparql-endpoint/-/fetch-sparql-endpoint-4.1.0.tgz",
+      "integrity": "sha512-RQwr4+RpEiWZqubPCv05t7t1Y8ZDAmiJ4cCo0Ee9vmet4bjnDIiZIpAtJn9NMLBeVxpZfxGiPFcX6V0v2yVcUA==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/readable-stream": "^2.3.11",
+        "@types/sparqljs": "^3.1.3",
+        "abort-controller": "^3.0.0",
+        "cross-fetch": "^3.0.6",
+        "is-stream": "^2.0.0",
+        "minimist": "^1.2.0",
+        "n3": "^1.6.3",
+        "rdf-string": "^1.6.0",
+        "readable-web-to-node-stream": "^3.0.2",
+        "sparqljs": "^3.1.2",
+        "sparqljson-parse": "^2.2.0",
+        "sparqlxml-parse": "^2.1.1",
+        "stream-to-string": "^1.1.0"
+      },
+      "bin": {
+        "fetch-sparql-endpoint": "bin/fetch-sparql-endpoint.js"
+      }
+    },
+    "node_modules/fetch-sparql-endpoint/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/file-entry-cache": {
@@ -2061,6 +4732,11 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
       "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ=="
     },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -2107,6 +4783,19 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -2138,6 +4827,14 @@
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -2291,6 +4988,30 @@
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="
     },
+    "node_modules/graphql": {
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
+      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/graphql-to-sparql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/graphql-to-sparql/-/graphql-to-sparql-3.0.1.tgz",
+      "integrity": "sha512-A+RwB99o66CUj+XuqtP/u3P7fGS/qF6P+/jhNl1BE/JZ2SCnkrODvV0LADuJeCDmPh45fDhq+GTDVoN1ZQHYFw==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "graphql": "^15.5.2",
+        "jsonld-context-parser": "^2.0.2",
+        "minimist": "^1.2.0",
+        "rdf-data-factory": "^1.1.0",
+        "sparqlalgebrajs": "^4.0.0"
+      },
+      "bin": {
+        "graphql-to-sparql": "bin/graphql-to-sparql.js"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
@@ -2354,6 +5075,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
@@ -2363,6 +5093,24 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.0.0.tgz",
+      "integrity": "sha512-uxbSI98wmFT/G4P2zXx4OVx04qWUmyFPrD2/CNepa2Zo3GPNaCaaxElDgwUrwYWkK1nr9fft0Ya8dws8coDLLQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
       }
     },
     "node_modules/http-errors": {
@@ -2378,6 +5126,14 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-link-header": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.1.1.tgz",
+      "integrity": "sha512-mW3N/rTYpCn99s1do0zx6nzFZSwLH9HGfUM4ZqLWJ16ylmYaC2v5eYGqrNTQlByx8AzUgGI+V/32gXPugs1+Sw==",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/human-signals": {
@@ -2426,6 +5182,11 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/immutable": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.4.tgz",
+      "integrity": "sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA=="
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -2603,6 +5364,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-generator-function": {
@@ -2938,6 +5707,58 @@
         "node": ">=14"
       }
     },
+    "node_modules/jsonld-context-parser": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-2.4.0.tgz",
+      "integrity": "sha512-ZYOfvh525SdPd9ReYY58dxB3E2RUEU4DJ6ZibO8AitcowPeBH4L5rCAitE2om5G1P+HMEgYEYEr4EZKbVN4tpA==",
+      "dependencies": {
+        "@types/http-link-header": "^1.0.1",
+        "@types/node": "^18.0.0",
+        "cross-fetch": "^3.0.6",
+        "http-link-header": "^1.0.2",
+        "relative-to-absolute-iri": "^1.0.5"
+      },
+      "bin": {
+        "jsonld-context-parse": "bin/jsonld-context-parse.js"
+      }
+    },
+    "node_modules/jsonld-context-parser/node_modules/@types/node": {
+      "version": "18.19.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.3.tgz",
+      "integrity": "sha512-k5fggr14DwAytoA/t8rPrIz++lXK7/DqckthCmoZOKNsEbJkId4Z//BqgApXBUGrGddrigYa1oqheo/7YmW4rg==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/jsonld-streaming-parser": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-3.3.0.tgz",
+      "integrity": "sha512-6aWiAsWGZioTB/vNQ3KenREz9ddEOliZoEETi+jLrlL7+vkgMeHjnxyFlGe4UOCU7SVUNPhz/lgLGZjnxgVYtA==",
+      "dependencies": {
+        "@bergos/jsonparse": "^1.4.0",
+        "@rdfjs/types": "*",
+        "@types/http-link-header": "^1.0.1",
+        "@types/readable-stream": "^2.3.13",
+        "buffer": "^6.0.3",
+        "canonicalize": "^1.0.1",
+        "http-link-header": "^1.0.2",
+        "jsonld-context-parser": "^2.4.0",
+        "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.0.0"
+      }
+    },
+    "node_modules/jsonld-streaming-serializer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/jsonld-streaming-serializer/-/jsonld-streaming-serializer-2.1.0.tgz",
+      "integrity": "sha512-COHdLoeMTnrqHMoFhN3PoAwqnrKrpPC7/ACb0WbELYvt+HSOIFN3v4IJP7fOtLNQ4GeaeYkvbeWJ7Jo4EjxMDw==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/readable-stream": "^2.3.13",
+        "buffer": "^6.0.3",
+        "jsonld-context-parser": "^2.0.0",
+        "readable-stream": "^4.0.0"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -2959,6 +5780,11 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
+    },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
     },
     "node_modules/ky": {
       "version": "0.33.3",
@@ -3076,6 +5902,27 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
     },
+    "node_modules/logform": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.6.0.tgz",
+      "integrity": "sha512-1ulHeNPp6k/LD8H91o7VYFBng5i1BDE7HoKxVbZiGFidS1Rj65qcywLxX+pVfAPoQJEjRdvKcusKwOupHCVOVQ==",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/logform/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -3121,6 +5968,36 @@
         "node": ">= 8"
       }
     },
+    "node_modules/microdata-rdf-streaming-parser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/microdata-rdf-streaming-parser/-/microdata-rdf-streaming-parser-2.0.1.tgz",
+      "integrity": "sha512-oEEYP3OwPGOtoE4eIyJvX1eJXI7VkGR4gKYqpEufaRXc2ele/Tkid/KMU3Los13wGrOq6woSxLEGOYSHzpRvwA==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "htmlparser2": "^8.0.0",
+        "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.1.0",
+        "relative-to-absolute-iri": "^1.0.2"
+      }
+    },
+    "node_modules/microdata-rdf-streaming-parser/node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
@@ -3164,6 +6041,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -3224,6 +6106,11 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
+    },
+    "node_modules/negotiate": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/negotiate/-/negotiate-1.0.1.tgz",
+      "integrity": "sha512-KBCIM4dAIT9j/pSXLHHQbZG74NmKNXTtxU2zHN0HG6uzzuFE01m1UdGoUmVHmACiBuCAOL7KwfqSW1oUQBj/vg=="
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
@@ -3415,6 +6302,14 @@
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "dependencies": {
+        "fn.name": "1.x.x"
       }
     },
     "node_modules/onetime": {
@@ -3700,6 +6595,11 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/promise-polyfill": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-1.1.6.tgz",
+      "integrity": "sha512-7rrONfyLkDEc7OJ5QBkqa4KI4EBhCd340xRuIUPGCfu13znS+vx+VDdrT9ODAJHlXm7w4lbxN3DRjyv58EuzDg=="
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -3776,6 +6676,188 @@
         "node": ">=12"
       }
     },
+    "node_modules/rdf-data-factory": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.2.tgz",
+      "integrity": "sha512-TfQD63Lokabd09ES1jAtKK8AA6rkr9rwyUBGo6olOt1CE0Um36CUQIqytyf0am2ouBPR0l7SaHxCiMcPGHkt1A==",
+      "dependencies": {
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/rdf-isomorphic": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/rdf-isomorphic/-/rdf-isomorphic-1.3.1.tgz",
+      "integrity": "sha512-6uIhsXTVp2AtO6f41PdnRV5xZsa0zVZQDTBdn0br+DZuFf5M/YD+T6m8hKDUnALI6nFL/IujTMLgEs20MlNidQ==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "hash.js": "^1.1.7",
+        "rdf-string": "^1.6.0",
+        "rdf-terms": "^1.7.0"
+      }
+    },
+    "node_modules/rdf-js": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-js/-/rdf-js-4.0.2.tgz",
+      "integrity": "sha512-ApvlFa/WsQh8LpPK/6hctQwG06Z9ztQQGWVtrcrf9L6+sejHNXLPOqL+w7q3hF+iL0C4sv3AX1PUtGkLNzyZ0Q==",
+      "dependencies": {
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/rdf-literal": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/rdf-literal/-/rdf-literal-1.3.1.tgz",
+      "integrity": "sha512-+o/PGOfJchyay9Rjrvi/oveRJACnt2WFO3LhEvtPlsRD1tFmwVUCMU+s33FtQprMo+z1ohFrv/yfEQ6Eym4KgQ==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.0"
+      }
+    },
+    "node_modules/rdf-object": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/rdf-object/-/rdf-object-1.14.0.tgz",
+      "integrity": "sha512-/KSUWr7onDtL7d81kOpcUzJ2vHYOYJc2KU9WzBZRYydBhK0Sksh5Hg4VCQNaxUEvYEgdrrTuq9SLpOOCmag0rQ==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "jsonld-context-parser": "^2.0.2",
+        "rdf-data-factory": "^1.1.0",
+        "rdf-string": "^1.6.0",
+        "streamify-array": "^1.0.1"
+      }
+    },
+    "node_modules/rdf-parse": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/rdf-parse/-/rdf-parse-2.3.2.tgz",
+      "integrity": "sha512-TOeI7FKlyr/GupfGaXZvpMLzvByOrtwt4zHLMuuy3deNGse9QyhHsspVraZam491sIgBogdchzcUqkf2WXnAsg==",
+      "dependencies": {
+        "@comunica/actor-http-fetch": "^2.0.1",
+        "@comunica/actor-http-proxy": "^2.0.1",
+        "@comunica/actor-rdf-parse-html": "^2.0.1",
+        "@comunica/actor-rdf-parse-html-microdata": "^2.0.1",
+        "@comunica/actor-rdf-parse-html-rdfa": "^2.0.1",
+        "@comunica/actor-rdf-parse-html-script": "^2.0.1",
+        "@comunica/actor-rdf-parse-jsonld": "^2.0.1",
+        "@comunica/actor-rdf-parse-n3": "^2.0.1",
+        "@comunica/actor-rdf-parse-rdfxml": "^2.0.1",
+        "@comunica/actor-rdf-parse-shaclc": "^2.6.2",
+        "@comunica/actor-rdf-parse-xml-rdfa": "^2.0.1",
+        "@comunica/bus-http": "^2.0.1",
+        "@comunica/bus-init": "^2.0.1",
+        "@comunica/bus-rdf-parse": "^2.0.1",
+        "@comunica/bus-rdf-parse-html": "^2.0.1",
+        "@comunica/config-query-sparql": "^2.0.1",
+        "@comunica/core": "^2.0.1",
+        "@comunica/mediator-combine-pipeline": "^2.0.1",
+        "@comunica/mediator-combine-union": "^2.0.1",
+        "@comunica/mediator-number": "^2.0.1",
+        "@comunica/mediator-race": "^2.0.1",
+        "@rdfjs/types": "*",
+        "readable-stream": "^4.3.0",
+        "stream-to-string": "^1.2.0"
+      }
+    },
+    "node_modules/rdf-quad": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/rdf-quad/-/rdf-quad-1.5.0.tgz",
+      "integrity": "sha512-LnCYx8XbRVW1wr6UiZPSy2Tv7bXAtEwuyck/68dANhFu8VMnGS+QfUNP3b9YI6p4Bfd/fyDx5E3x81IxGV6BzA==",
+      "dependencies": {
+        "rdf-data-factory": "^1.0.1",
+        "rdf-literal": "^1.2.0",
+        "rdf-string": "^1.5.0"
+      }
+    },
+    "node_modules/rdf-store-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-store-stream/-/rdf-store-stream-2.0.0.tgz",
+      "integrity": "sha512-FKRsA5XUdhFVMx+jg4JCBM76B4ZcXVKyilr8GJrlfkHB2IZSIgLxY2XHIsewkDfm/yAtXHvPT0PaeQg4Mbqa6g==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "rdf-stores": "^1.0.0"
+      }
+    },
+    "node_modules/rdf-stores": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-stores/-/rdf-stores-1.0.0.tgz",
+      "integrity": "sha512-wqp7M5409rbhpWQE0C1vyVysbz++aD2vEkZ6yueSxhDtyLvznS41R3cKiuUpm3ikc/yTpaCZwPo4iyKEaAwBIg==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.0",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-string": "^1.6.2",
+        "rdf-terms": "^1.9.1"
+      }
+    },
+    "node_modules/rdf-streaming-store": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/rdf-streaming-store/-/rdf-streaming-store-1.1.0.tgz",
+      "integrity": "sha512-C/5NTKGpKrNJ5VUo42DtGFsXYDlP3rx/u4C6gEBuSn+6eVFahjFdUDgNGcPtVyhCQkctRCj3GT1lX9UeyoXWtw==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/n3": "^1.10.4",
+        "@types/readable-stream": "^2.3.15",
+        "n3": "^1.16.3",
+        "rdf-string": "^1.6.2",
+        "rdf-terms": "^1.9.1",
+        "readable-stream": "^4.3.0"
+      }
+    },
+    "node_modules/rdf-string": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.6.3.tgz",
+      "integrity": "sha512-HIVwQ2gOqf+ObsCLSUAGFZMIl3rh9uGcRf1KbM85UDhKqP+hy6qj7Vz8FKt3GA54RiThqK3mNcr66dm1LP0+6g==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.0"
+      }
+    },
+    "node_modules/rdf-string-ttl": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/rdf-string-ttl/-/rdf-string-ttl-1.3.2.tgz",
+      "integrity": "sha512-yqolaVoUvTaSC5aaQuMcB4BL54G/pCGsV4jQH87f0TvAx8zHZG0koh7XWrjva/IPGcVb1QTtaeEdfda5mcddJg==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.0"
+      }
+    },
+    "node_modules/rdf-terms": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-1.11.0.tgz",
+      "integrity": "sha512-iKlVgnMopRKl9pHVNrQrax7PtZKRCT/uJIgYqvuw1VVQb88zDvurtDr1xp0rt7N9JtKtFwUXoIQoEsjyRo20qQ==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.0",
+        "rdf-string": "^1.6.0"
+      }
+    },
+    "node_modules/rdfa-streaming-parser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdfa-streaming-parser/-/rdfa-streaming-parser-2.0.1.tgz",
+      "integrity": "sha512-7Yyaj030LO7iQ38Wh/RNLVeYrVFJeyx3dpCK7C1nvX55eIN/gE4HWfbg4BYI9X7Bd+eUIUMVeiKYLmYjV6apow==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "htmlparser2": "^8.0.0",
+        "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.0.0",
+        "relative-to-absolute-iri": "^1.0.2"
+      }
+    },
+    "node_modules/rdfa-streaming-parser/node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
     "node_modules/rdflib": {
       "version": "2.2.33",
       "resolved": "https://registry.npmjs.org/rdflib/-/rdflib-2.2.33.tgz",
@@ -3788,6 +6870,21 @@
         "jsonld": "^8.1.1",
         "n3": "^1.16.4",
         "solid-namespace": "^0.5.3"
+      }
+    },
+    "node_modules/rdfxml-streaming-parser": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/rdfxml-streaming-parser/-/rdfxml-streaming-parser-2.4.0.tgz",
+      "integrity": "sha512-f+tdI1wxOiPzMbFWRtOwinwPsqac0WIN80668yFKcVdFCSTGOWTM70ucQGUSdDZZo7pce/UvZgV0C3LDj0P7tg==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@rubensworks/saxes": "^6.0.1",
+        "@types/readable-stream": "^2.3.13",
+        "buffer": "^6.0.3",
+        "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.4.2",
+        "relative-to-absolute-iri": "^1.0.0",
+        "validate-iri": "^1.0.0"
       }
     },
     "node_modules/react-is": {
@@ -3808,6 +6905,39 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/readable-stream-node-to-web": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/readable-stream-node-to-web/-/readable-stream-node-to-web-1.0.1.tgz",
+      "integrity": "sha512-OGzi2VKLa8H259kAx7BIwuRrXHGcxeHj4RdASSgEGBP9Q2wowdPvBc65upF4Q9O05qWgKqBw1+9PiLTtObl7uQ=="
+    },
+    "node_modules/readable-web-to-node-stream": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
+      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
+      "dependencies": {
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/readable-web-to-node-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -3859,6 +6989,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
+    "node_modules/relative-to-absolute-iri": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/relative-to-absolute-iri/-/relative-to-absolute-iri-1.0.7.tgz",
+      "integrity": "sha512-Xjyl4HmIzg2jzK/Un2gELqbcE8Fxy85A/aLSHE6PE/3+OGsFwmKVA1vRyGaz6vLWSqLDMHA+5rjD/xbibSQN1Q=="
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -4083,6 +7226,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+      "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -4133,6 +7284,25 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
+    "node_modules/shaclc-parse": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/shaclc-parse/-/shaclc-parse-1.4.0.tgz",
+      "integrity": "sha512-zyxjIYQH2ghg/wtMvOp+4Nr6aK8j9bqFiVT3w47K8WHPYN+S3Zgnh2ybT+dGgMwo9KjiOoywxhjC7d8Z6GCmfA==",
+      "dependencies": {
+        "@rdfjs/types": "^1.1.0",
+        "n3": "^1.16.3"
+      }
+    },
+    "node_modules/shaclc-write": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/shaclc-write/-/shaclc-write-1.4.2.tgz",
+      "integrity": "sha512-aejD8fNgTfTINInjlwW7oz4GbmIJmDFJu4Tc3WVhmMH2QV24F+Ey/I/obMP/cQu/LwcfX7O2eu7bI9RUFeDMWw==",
+      "dependencies": {
+        "@jeswr/prefixcc": "^1.2.1",
+        "n3": "^1.16.3",
+        "rdf-string-ttl": "^1.3.2"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -4171,6 +7341,19 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -4186,6 +7369,86 @@
       "integrity": "sha512-b2u2qkrRa0yrcc/jh6Nv0/mkwMyL4fMSNZtKG4dv3IxQtZOEUB8O6Xe7GrkoQaRoGrbUxRzbve9GHJD0w7p+KA==",
       "dependencies": {
         "standard": "^17.0.0"
+      }
+    },
+    "node_modules/spark-md5": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.2.tgz",
+      "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw=="
+    },
+    "node_modules/sparqlalgebrajs": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-4.3.2.tgz",
+      "integrity": "sha512-5OZCKVlBz/45+on5jWND6OHtzB9EiuY1e/M93WnYzmO07GG3thUyDz5G6DBXZtg2e14n+FhMK/KiLUXKHtM5qw==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/sparqljs": "^3.1.3",
+        "fast-deep-equal": "^3.1.3",
+        "minimist": "^1.2.6",
+        "rdf-data-factory": "^1.1.0",
+        "rdf-isomorphic": "^1.3.0",
+        "rdf-string": "^1.6.0",
+        "rdf-terms": "^1.10.0",
+        "sparqljs": "^3.7.1"
+      },
+      "bin": {
+        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
+      }
+    },
+    "node_modules/sparqljs": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.7.1.tgz",
+      "integrity": "sha512-I1jYMtcwDkgCEqQ4eQuQIhB8hFAlRAJ6YDXDcV54XztaJaYRFqJlidHt77S3j8Mfh6kY6GK04dXPEIopxbEeuQ==",
+      "dependencies": {
+        "rdf-data-factory": "^1.1.2"
+      },
+      "bin": {
+        "sparqljs": "bin/sparql-to-json"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/sparqljson-parse": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/sparqljson-parse/-/sparqljson-parse-2.2.0.tgz",
+      "integrity": "sha512-2TfvNvUsaJyWfCrq3ExdDdbF9LBLzIUCricg+D1YCYbbmyTzscgCtRk4KcIyJF178DtfCt4BkKzbKl8IXMHp8w==",
+      "dependencies": {
+        "@bergos/jsonparse": "^1.4.1",
+        "@rdfjs/types": "*",
+        "@types/readable-stream": "^2.3.13",
+        "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.0.0"
+      }
+    },
+    "node_modules/sparqljson-to-tree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sparqljson-to-tree/-/sparqljson-to-tree-3.0.1.tgz",
+      "integrity": "sha512-WKDWCP6CM0Oa/OmzJJDpFudfa0yCcYnQoSPVb4RBp8XOYDOPn75fzrZURYQBSng/BUieT/zxaw68tstI6G3pSw==",
+      "dependencies": {
+        "rdf-literal": "^1.2.0",
+        "sparqljson-parse": "^2.0.0"
+      }
+    },
+    "node_modules/sparqlxml-parse": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/sparqlxml-parse/-/sparqlxml-parse-2.1.1.tgz",
+      "integrity": "sha512-71sltShF6gDAzuKWEHNeij7r0Mv5VqRrvJing6W4WHJ12GRe6+t1IRTv6MeqxYN3XJmKevs7B3HCBUo7wceeJQ==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@rubensworks/saxes": "^6.0.1",
+        "@types/readable-stream": "^2.3.13",
+        "buffer": "^6.0.3",
+        "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.0.0"
+      }
+    },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/standard": {
@@ -4260,12 +7523,43 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/stream-to-string": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/stream-to-string/-/stream-to-string-1.2.1.tgz",
+      "integrity": "sha512-WsvTDNF8UYs369Yko3pcdTducQtYpzEZeOV7cTuReyFvOoA9S/DLJ6sYK+xPafSPHhUMpaxiljKYnT6JSFztIA==",
+      "dependencies": {
+        "promise-polyfill": "^1.1.6"
+      }
+    },
+    "node_modules/streamify-array": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/streamify-array/-/streamify-array-1.0.1.tgz",
+      "integrity": "sha512-ZnswaBcC6B1bhPLSQOlC6CdaDUSzU0wr2lvvHpbHNms8V7+DLd8uEAzDAWpsjxbFkijBHhuObFO/qqu52DZUMA=="
+    },
+    "node_modules/streamify-string": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/streamify-string/-/streamify-string-1.0.1.tgz",
+      "integrity": "sha512-RXvBglotrvSIuQQ7oC55pdV40wZ/17gTb68ipMC4LA0SqMN4Sqfsf31Dpei7qXpYqZQ8ueVnPglUvtep3tlhqw=="
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/string.prototype.matchall": {
@@ -4409,6 +7703,11 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -4450,6 +7749,14 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
     },
     "node_modules/ts-api-utils": {
       "version": "1.0.3",
@@ -4614,6 +7921,11 @@
         "node": ">=14.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    },
     "node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -4647,6 +7959,16 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/uritemplate": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/uritemplate/-/uritemplate-0.3.4.tgz",
+      "integrity": "sha512-enADBvHfhjrwxFMTVWeIIYz51SZ91uC6o2MR/NQTVljJB6HTZ8eQL3Q7JBj3RxNISA14MOwJaU3vpf5R6dyxHA=="
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
     "node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -4654,6 +7976,11 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/validate-iri": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/validate-iri/-/validate-iri-1.0.1.tgz",
+      "integrity": "sha512-gLXi7351CoyVVQw8XE5sgpYawRKatxE7kj/xmCxXOZS1kMdtcqC0ILIqLuVEVnAUQSL/evOGG3eQ+8VgbdnstA=="
     },
     "node_modules/version-guard": {
       "version": "1.1.1",
@@ -4670,6 +7997,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/web-streams-ponyfill": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/web-streams-ponyfill/-/web-streams-ponyfill-1.4.2.tgz",
+      "integrity": "sha512-LCHW+fE2UBJ2vjhqJujqmoxh1ytEDEr0dPO3CabMdMDJPKmsaxzS90V1Ar6LtNE5VHLqxR4YMEj1i4lzMAccIA=="
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -4771,6 +8103,93 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/winston": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.11.0.tgz",
+      "integrity": "sha512-L3yR6/MzZAOl0DsysUXHVjOwv8mKZ71TrA/41EIduGpOOV5LQVodqN+QdQ6BS6PJ/RdIshZhq84P/fStEZkk7g==",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.4.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.5.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.6.0.tgz",
+      "integrity": "sha512-wbBA9PbPAHxKiygo7ub7BYRiKxms0tpfU2ljtWzb3SjRjv5yl6Ozuy/TkXf00HTAt+Uylo3gSkNwzc4ME0wiIg==",
+      "dependencies": {
+        "logform": "^2.3.2",
+        "readable-stream": "^3.6.0",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/winston/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/winston/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -4784,10 +8203,48 @@
         "node": ">=8"
       }
     },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
+    "@comunica/query-sparql": "^2.10.1",
     "body-parser": "^1.19.0",
     "cron": "^1.8.2",
     "crypto-js": "^4.0.0",
@@ -26,6 +27,7 @@
     "lodash.groupby": "^4.6.0",
     "lodash.uniq": "^4.5.0",
     "moment": "^2.29.1",
+    "n3": "^1.17.2",
     "rdflib": "^2.1.1",
     "uuid": "^8.3.1"
   }

--- a/queries/getPathsForFields.ts
+++ b/queries/getPathsForFields.ts
@@ -1,0 +1,255 @@
+import { queryStore } from '../utils';
+import N3 from 'n3';
+import { sparqlEscapeUri } from 'mu';
+
+/**
+ * Broken: union only returns the first branch in this query (but works in smaller example)
+ */
+export const getPathsForFieldsQuerySingleQuery = async function (
+  formStore: N3.Store,
+) {
+  /**
+   * here,
+   * - ?field is the form:field we're examining the path for
+   * - ?previous is the previous step in the path
+   * - ?step is the current step in the path (blank node)
+   * - ?node is the current predicate in the path UNLESS a modifier is applied, then it's a blank node
+   * - ?modifier is the modifier applied to the current predicate in the path if any
+   * - ?predicate is the predicate in the path if there is a modifier applied to it (e.g. inverse path)
+   *
+   * for instance, if the path has this shape:
+   * fields:1 sh:path ( [ sh:inversePath prov:generated ] dct:subject [ sh:inversePath besluit:behandelt ]  prov:startedAtTime ) ;
+   * the result will be:
+   * "field","previous","step","node","modifier","predicate"
+   * "fields:1",,"nodeID://b10098","nodeID://b10099","sh:inversePath","prov:generated"
+   * "fields:1","nodeID://b10100","nodeID://b10101","nodeID://b10102","sh:inversePath","besluit:behandelt"
+   * "fields:1","nodeID://b10098","nodeID://b10100","dct:subject",,
+   * "fields:1","nodeID://b10101","nodeID://b10103","prov:startedAtTime",,
+   */
+  const query = `
+    PREFIX form:  <http://lblod.data.gift/vocabularies/forms/>
+    PREFIX sh: <http://www.w3.org/ns/shacl#>
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+    SELECT
+    ?field ?previous ?step ?node ?modifier ?predicate
+    WHERE {
+      ?field a form:Field.
+      ?field sh:path ?path.
+
+      {
+        {
+          # simple paths with direct predicates
+          # (need to repeat previous condition because else our union block is empty)
+          ?field sh:path ?path.
+          BIND(?path as ?step)
+          BIND(?path as ?node)
+          FILTER(!isBlank(?step))
+        } UNION {
+          # first step of a complex path (blank node)
+          ?path rdf:first ?node.
+          BIND(?path as ?step)
+        } UNION {
+          # mid or last step of a complex path (blank node)
+          ?path rdf:rest+ ?step.
+          FILTER(?step != rdf:nil)
+          ?step rdf:first ?node.
+          ?previous rdf:rest ?step.
+        }
+      }
+      OPTIONAL {
+        ?node ?modifier ?predicate.
+      }
+    } ORDER BY ?field ?step
+  `;
+  const bindings = await queryStore(query, formStore);
+  const modifierLookup = {
+    // only inverse path is supported for now
+    'http://www.w3.org/ns/shacl#inversePath': '^',
+  };
+  return bindings.map((binding) => {
+    const field = binding.get('field')?.value || 'cannot be undefined';
+    const previous = binding.get('previous')?.value;
+    const step = binding.get('step')?.value || 'cannot be undefined';
+    const node = binding.get('node')?.value || 'cannot be undefined';
+    const modifier = binding.get('modifier')?.value;
+    const predicate = binding.get('predicate')?.value;
+
+    const sparqlModifier = modifier && modifierLookup[modifier];
+    if (modifier && !sparqlModifier) {
+      throw new Error(`Unsupported modifier ${modifier}`);
+    }
+    const realPredicate = sparqlModifier
+      ? `${sparqlModifier}${sparqlEscapeUri(predicate)}`
+      : sparqlEscapeUri(node);
+
+    return {
+      field,
+      predicate: realPredicate,
+      previous,
+      node: step,
+    };
+  });
+};
+
+export const getSimplePaths = async function (formStore: N3.Store) {
+  const query = `
+    PREFIX form:  <http://lblod.data.gift/vocabularies/forms/>
+    PREFIX sh: <http://www.w3.org/ns/shacl#>
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+    SELECT
+    ?field ?path
+    WHERE {
+      ?field a form:Field.
+      ?field sh:path ?path.
+      # simple paths with direct predicates
+      ?field sh:path ?path.
+      FILTER(!isBlank(?path))
+    }
+  `;
+  const bindings = await queryStore(query, formStore);
+  return bindings.map((binding) => {
+    const field = binding.get('field')?.value || 'cannot be undefined';
+    const path = binding.get('path')?.value || 'cannot be undefined';
+
+    const predicate = sparqlEscapeUri(path);
+
+    return {
+      field,
+      predicate,
+      previous: undefined,
+      node: path,
+    };
+  });
+};
+
+export const getComplexPathHeads = async function (formStore: N3.Store) {
+  const query = `
+    PREFIX form:  <http://lblod.data.gift/vocabularies/forms/>
+    PREFIX sh: <http://www.w3.org/ns/shacl#>
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+    SELECT
+    ?field ?path ?node ?modifier ?predicate
+    WHERE {
+      ?field a form:Field.
+      ?field sh:path ?path.
+
+      # first step of a complex path (blank node)
+      ?path rdf:first ?node.
+      OPTIONAL {
+        ?node ?modifier ?predicate.
+      }
+    }
+  `;
+  const bindings = await queryStore(query, formStore);
+  const modifierLookup = {
+    // only inverse path is supported for now
+    'http://www.w3.org/ns/shacl#inversePath': '^',
+  };
+  return bindings.map((binding) => {
+    const field = binding.get('field')?.value || 'cannot be undefined';
+    const step = binding.get('path')?.value || 'cannot be undefined';
+    const node = binding.get('node')?.value || 'cannot be undefined';
+    const modifier = binding.get('modifier')?.value;
+    const predicate = binding.get('predicate')?.value;
+
+    const sparqlModifier = modifier && modifierLookup[modifier];
+    if (modifier && !sparqlModifier) {
+      throw new Error(`Unsupported modifier ${modifier}`);
+    }
+    const realPredicate = sparqlModifier
+      ? `${sparqlModifier}${sparqlEscapeUri(predicate)}`
+      : sparqlEscapeUri(node);
+
+    return {
+      field,
+      predicate: realPredicate,
+      previous: undefined,
+      node: step,
+    };
+  });
+};
+
+export const getComplexPathsTails = async function (formStore: N3.Store) {
+  const query = `
+    PREFIX form:  <http://lblod.data.gift/vocabularies/forms/>
+    PREFIX sh: <http://www.w3.org/ns/shacl#>
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+    SELECT
+    ?field ?previous ?step ?node ?modifier ?predicate
+    WHERE {
+      ?field a form:Field.
+      ?field sh:path ?path.
+      # mid or last step of a complex path (blank node)
+      ?path rdf:rest+ ?step.
+      FILTER(?step != rdf:nil)
+      ?step rdf:first ?node.
+      ?previous rdf:rest ?step.
+      OPTIONAL {
+        ?node ?modifier ?predicate.
+      }
+    } ORDER BY ?field ?step
+  `;
+  const bindings = await queryStore(query, formStore);
+  const modifierLookup = {
+    // only inverse path is supported for now
+    'http://www.w3.org/ns/shacl#inversePath': '^',
+  };
+  return bindings.map((binding) => {
+    const field = binding.get('field')?.value || 'cannot be undefined';
+    const previous = binding.get('previous')?.value;
+    const step = binding.get('step')?.value || 'cannot be undefined';
+    const node = binding.get('node')?.value || 'cannot be undefined';
+    const modifier = binding.get('modifier')?.value;
+    const predicate = binding.get('predicate')?.value;
+
+    const sparqlModifier = modifier && modifierLookup[modifier];
+    if (modifier && !sparqlModifier) {
+      throw new Error(`Unsupported modifier ${modifier}`);
+    }
+    const realPredicate = sparqlModifier
+      ? `${sparqlModifier}${sparqlEscapeUri(predicate)}`
+      : sparqlEscapeUri(node);
+
+    return {
+      field,
+      predicate: realPredicate,
+      previous,
+      node: step,
+    };
+  });
+};
+
+/**
+ * Were are combining 3 different queries. This is to avoid a bug in the union implementation of comunica.
+ * This only works because comunica uses consistent blank node identifiers across queries.
+ *
+ * here,
+ * - ?field is the form:field we're examining the path for
+ * - ?previous is the previous step in the path
+ * - ?step is the current step in the path (blank node)
+ * - ?node is the current predicate in the path UNLESS a modifier is applied, then it's a blank node
+ * - ?modifier is the modifier applied to the current predicate in the path if any
+ * - ?predicate is the predicate in the path if there is a modifier applied to it (e.g. inverse path)
+ *
+ * for instance, if the path has this shape:
+ * fields:1 sh:path ( [ sh:inversePath prov:generated ] dct:subject [ sh:inversePath besluit:behandelt ]  prov:startedAtTime ) ;
+ * the result will be:
+ * "field","previous","step","node","modifier","predicate"
+ * "fields:1",,"nodeID://b10098","nodeID://b10099","sh:inversePath","prov:generated"
+ * "fields:1","nodeID://b10100","nodeID://b10101","nodeID://b10102","sh:inversePath","besluit:behandelt"
+ * "fields:1","nodeID://b10098","nodeID://b10100","dct:subject",,
+ * "fields:1","nodeID://b10101","nodeID://b10103","prov:startedAtTime",,
+ */
+export const getPathsForFieldsQuery = async function (formStore: N3.Store) {
+  const [simple, heads, tails] = await Promise.all([
+    getSimplePaths(formStore),
+    getComplexPathHeads(formStore),
+    getComplexPathsTails(formStore),
+  ]);
+  const bindings = [...simple, ...heads, ...tails];
+  return bindings;
+};

--- a/queries/getPathsForFields.ts
+++ b/queries/getPathsForFields.ts
@@ -90,6 +90,9 @@ export const getPathsForFieldsQuerySingleQuery = async function (
 };
 
 const getSimplePaths = async function (formStore: N3.Store) {
+  // NOTE: we don't support simple paths with modifiers (e.g. inverse path),
+  // in that case, just write it as ( [ sh:inversePath <predicate> ] ) instead of
+  // [ sh:inversePath <predicate> ], i.e. make it a complex path
   const query = `
     PREFIX form:  <http://lblod.data.gift/vocabularies/forms/>
     PREFIX sh: <http://www.w3.org/ns/shacl#>

--- a/queries/getPathsForFields.ts
+++ b/queries/getPathsForFields.ts
@@ -1,6 +1,7 @@
 import { queryStore } from '../utils';
 import N3 from 'n3';
 import { sparqlEscapeUri } from 'mu';
+import { modifierLookup } from '../utils';
 
 /**
  * Broken: union only returns the first branch in this query (but works in smaller example)
@@ -63,10 +64,6 @@ export const getPathsForFieldsQuerySingleQuery = async function (
     } ORDER BY ?field ?step
   `;
   const bindings = await queryStore(query, formStore);
-  const modifierLookup = {
-    // only inverse path is supported for now
-    'http://www.w3.org/ns/shacl#inversePath': '^',
-  };
   return bindings.map((binding) => {
     const field = binding.get('field')?.value || 'cannot be undefined';
     const previous = binding.get('previous')?.value;
@@ -92,7 +89,7 @@ export const getPathsForFieldsQuerySingleQuery = async function (
   });
 };
 
-export const getSimplePaths = async function (formStore: N3.Store) {
+const getSimplePaths = async function (formStore: N3.Store) {
   const query = `
     PREFIX form:  <http://lblod.data.gift/vocabularies/forms/>
     PREFIX sh: <http://www.w3.org/ns/shacl#>
@@ -124,7 +121,7 @@ export const getSimplePaths = async function (formStore: N3.Store) {
   });
 };
 
-export const getComplexPathHeads = async function (formStore: N3.Store) {
+const getComplexPathHeads = async function (formStore: N3.Store) {
   const query = `
     PREFIX form:  <http://lblod.data.gift/vocabularies/forms/>
     PREFIX sh: <http://www.w3.org/ns/shacl#>
@@ -144,10 +141,6 @@ export const getComplexPathHeads = async function (formStore: N3.Store) {
     }
   `;
   const bindings = await queryStore(query, formStore);
-  const modifierLookup = {
-    // only inverse path is supported for now
-    'http://www.w3.org/ns/shacl#inversePath': '^',
-  };
   return bindings.map((binding) => {
     const field = binding.get('field')?.value || 'cannot be undefined';
     const step = binding.get('path')?.value || 'cannot be undefined';
@@ -172,7 +165,7 @@ export const getComplexPathHeads = async function (formStore: N3.Store) {
   });
 };
 
-export const getComplexPathsTails = async function (formStore: N3.Store) {
+const getComplexPathsTails = async function (formStore: N3.Store) {
   const query = `
     PREFIX form:  <http://lblod.data.gift/vocabularies/forms/>
     PREFIX sh: <http://www.w3.org/ns/shacl#>
@@ -194,10 +187,6 @@ export const getComplexPathsTails = async function (formStore: N3.Store) {
     } ORDER BY ?field ?step
   `;
   const bindings = await queryStore(query, formStore);
-  const modifierLookup = {
-    // only inverse path is supported for now
-    'http://www.w3.org/ns/shacl#inversePath': '^',
-  };
   return bindings.map((binding) => {
     const field = binding.get('field')?.value || 'cannot be undefined';
     const previous = binding.get('previous')?.value;

--- a/queries/getPathsForFields.ts
+++ b/queries/getPathsForFields.ts
@@ -21,11 +21,11 @@ export const getPathsForFieldsQuerySingleQuery = async function (
    * for instance, if the path has this shape:
    * fields:1 sh:path ( [ sh:inversePath prov:generated ] dct:subject [ sh:inversePath besluit:behandelt ]  prov:startedAtTime ) ;
    * the result will be:
-   * "field","previous","step","node","modifier","predicate"
-   * "fields:1",,"nodeID://b10098","nodeID://b10099","sh:inversePath","prov:generated"
+   * "field","previous(optional)","step","node","modifier(optional)","predicate(optional)"
+   * "fields:1",<void>,"nodeID://b10098","nodeID://b10099","sh:inversePath","prov:generated"
    * "fields:1","nodeID://b10100","nodeID://b10101","nodeID://b10102","sh:inversePath","besluit:behandelt"
-   * "fields:1","nodeID://b10098","nodeID://b10100","dct:subject",,
-   * "fields:1","nodeID://b10101","nodeID://b10103","prov:startedAtTime",,
+   * "fields:1","nodeID://b10098","nodeID://b10100","dct:subject",<void>,<void>
+   * "fields:1","nodeID://b10101","nodeID://b10103","prov:startedAtTime",<void>,<void>
    */
   const query = `
     PREFIX form:  <http://lblod.data.gift/vocabularies/forms/>
@@ -61,7 +61,7 @@ export const getPathsForFieldsQuerySingleQuery = async function (
       OPTIONAL {
         ?node ?modifier ?predicate.
       }
-    } ORDER BY ?field ?step
+    }
   `;
   const bindings = await queryStore(query, formStore);
   return bindings.map((binding) => {
@@ -84,7 +84,7 @@ export const getPathsForFieldsQuerySingleQuery = async function (
       field,
       predicate: realPredicate,
       previous,
-      node: step,
+      step,
     };
   });
 };
@@ -116,7 +116,7 @@ const getSimplePaths = async function (formStore: N3.Store) {
       field,
       predicate,
       previous: undefined,
-      node: path,
+      step: path,
     };
   });
 };
@@ -160,7 +160,7 @@ const getComplexPathHeads = async function (formStore: N3.Store) {
       field,
       predicate: realPredicate,
       previous: undefined,
-      node: step,
+      step,
     };
   });
 };
@@ -184,7 +184,7 @@ const getComplexPathsTails = async function (formStore: N3.Store) {
       OPTIONAL {
         ?node ?modifier ?predicate.
       }
-    } ORDER BY ?field ?step
+    }
   `;
   const bindings = await queryStore(query, formStore);
   return bindings.map((binding) => {
@@ -207,7 +207,7 @@ const getComplexPathsTails = async function (formStore: N3.Store) {
       field,
       predicate: realPredicate,
       previous,
-      node: step,
+      step,
     };
   });
 };

--- a/queries/getPathsForGenerators.ts
+++ b/queries/getPathsForGenerators.ts
@@ -1,0 +1,193 @@
+import { queryStore } from '../utils';
+import N3 from 'n3';
+import { sparqlEscapeUri } from 'mu';
+import { modifierLookup } from '../utils';
+
+const getSimplePaths = async function (
+  fieldWhere: string,
+  formStore: N3.Store,
+) {
+  const query = `
+    PREFIX form: <http://lblod.data.gift/vocabularies/forms/>
+    PREFIX sh: <http://www.w3.org/ns/shacl#>
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+    SELECT ?path ?modifier ?truePredicate ?field WHERE {
+      ${fieldWhere}
+
+      OPTIONAL {
+        ?formOrListing form:scope ?scope.
+        ?scope sh:path ?path.
+        FILTER(!isBlank(?path))
+
+        OPTIONAL {
+          ?path ?modifier ?truePredicate
+        }
+      }
+    }
+  `;
+  const bindings = await queryStore(query, formStore);
+  return bindings.map((binding) => {
+    const path = binding.get('path')?.value;
+    const field = binding.get('field')?.value || 'cannot be undefined';
+    const modifier = binding.get('modifier')?.value;
+    const truePredicate = binding.get('truePredicate')?.value;
+
+    if (!path) {
+      // no additional scope found
+      return {
+        step: undefined,
+        predicate: undefined,
+        previous: undefined,
+        field,
+      };
+    }
+
+    const sparqlModifier = modifier && modifierLookup[modifier];
+    if (modifier && !sparqlModifier) {
+      throw new Error(`Unsupported modifier ${modifier}`);
+    }
+    const realPredicate = sparqlModifier
+      ? `${sparqlModifier}${sparqlEscapeUri(truePredicate)}`
+      : sparqlEscapeUri(path);
+
+    return {
+      step: path,
+      predicate: realPredicate,
+      previous: undefined,
+      field,
+    };
+  });
+};
+
+const getPathHeads = async function (fieldWhere: string, formStore: N3.Store) {
+  const query = `
+    PREFIX form: <http://lblod.data.gift/vocabularies/forms/>
+    PREFIX sh: <http://www.w3.org/ns/shacl#>
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+    SELECT ?path ?predicate ?modifier ?truePredicate ?field WHERE {
+      ${fieldWhere}
+
+      ?formOrListing form:scope ?scope.
+      ?scope sh:path ?path.
+      ?path rdf:first ?predicate.
+      OPTIONAL {
+        ?predicate ?modifier ?truePredicate
+      }
+    }
+`;
+  const bindings = await queryStore(query, formStore);
+  const modifierLookup = {
+    // only inverse path is supported for now
+    'http://www.w3.org/ns/shacl#inversePath': '^',
+  };
+  return bindings.map((binding) => {
+    const path = binding.get('path')?.value || 'cannot be undefined';
+    const field = binding.get('field')?.value || 'cannot be undefined';
+    const predicate = binding.get('predicate')?.value || 'cannot be undefined';
+    const modifier = binding.get('modifier')?.value;
+    const truePredicate = binding.get('truePredicate')?.value;
+
+    const sparqlModifier = modifier && modifierLookup[modifier];
+    if (modifier && !sparqlModifier) {
+      throw new Error(`Unsupported modifier ${modifier}`);
+    }
+    const realPredicate = sparqlModifier
+      ? `${sparqlModifier}${sparqlEscapeUri(truePredicate)}`
+      : sparqlEscapeUri(predicate);
+
+    return {
+      step: path,
+      predicate: realPredicate,
+      previous: undefined,
+      field,
+    };
+  });
+};
+
+const getPathTails = async function (fieldWhere: string, formStore: N3.Store) {
+  const query = `
+    PREFIX form: <http://lblod.data.gift/vocabularies/forms/>
+    PREFIX sh: <http://www.w3.org/ns/shacl#>
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+    SELECT ?path ?tail ?previous ?predicate ?modifier ?truePredicate ?field WHERE {
+      ${fieldWhere}
+
+      ?formOrListing form:scope ?scope.
+      ?scope sh:path ?path.
+
+      ?path rdf:rest+ ?tail.
+      ?previous rdf:rest ?tail.
+      ?tail rdf:first ?predicate.
+      OPTIONAL {
+        ?predicate ?modifier ?truePredicate
+      }
+    }
+  `;
+  const bindings = await queryStore(query, formStore);
+  const modifierLookup = {
+    // only inverse path is supported for now
+    'http://www.w3.org/ns/shacl#inversePath': '^',
+  };
+  return bindings.map((binding) => {
+    const path = binding.get('path')?.value || 'cannot be undefined';
+    const field = binding.get('field')?.value || 'cannot be undefined';
+    const previous = binding.get('previous')?.value || 'cannot be undefined';
+    const predicate = binding.get('predicate')?.value || 'cannot be undefined';
+    const modifier = binding.get('modifier')?.value;
+    const truePredicate = binding.get('truePredicate')?.value;
+
+    const sparqlModifier = modifier && modifierLookup[modifier];
+    if (modifier && !sparqlModifier) {
+      throw new Error(`Unsupported modifier ${modifier}`);
+    }
+    const realPredicate = sparqlModifier
+      ? `${sparqlModifier}${sparqlEscapeUri(truePredicate)}`
+      : sparqlEscapeUri(predicate);
+
+    return {
+      step: path,
+      predicate: realPredicate,
+      previous,
+      field,
+    };
+  });
+};
+
+/**
+ * Were are combining 3 different queries. This is to avoid a bug in the union implementation of comunica.
+ * This only works because comunica uses consistent blank node identifiers across queries.
+ *
+ * here,
+ * - step is the current step in the path (blank node) (or if a simple path, the predicate)
+ * - previous is the previous step in the scope's path if it exists
+ * - predicate is the predicate on the current step in the scope's path if it exists, possibly with a ^ modifier
+ * - field is the predicate that the generator adds
+ *
+ */
+export const getPathsForGeneratorQuery = async function (formStore: N3.Store) {
+  const generatorWhere = `
+  ?formOrListing (form:createGenerator|form:initGenerator) ?generator.
+      ?generator form:prototype/form:shape ?generatorShape.
+  		?generatorShape ?field ?generatorO.
+  `;
+
+  const uuidWhere = `
+  ?formOrListing (form:createGenerator|form:initGenerator) ?generator.
+  ?generator form:dataGenerator form:addMuUuid.
+  VALUES (?field) { ( <http://mu.semte.ch/vocabularies/core/uuid> ) }
+  `;
+
+  const paths = await Promise.all([
+    getSimplePaths(generatorWhere, formStore),
+    getPathHeads(generatorWhere, formStore),
+    getPathTails(generatorWhere, formStore),
+    getSimplePaths(uuidWhere, formStore),
+    getPathHeads(uuidWhere, formStore),
+    getPathTails(uuidWhere, formStore),
+  ]);
+  const bindings = paths.flat();
+  return bindings;
+};

--- a/queries/getPathsForGenerators.ts
+++ b/queries/getPathsForGenerators.ts
@@ -7,6 +7,9 @@ const getSimplePaths = async function (
   fieldWhere: string,
   formStore: N3.Store,
 ) {
+  // NOTE: we don't support simple paths with modifiers (e.g. inverse path),
+  // in that case, just write it as ( [ sh:inversePath <predicate> ] ) instead of
+  // [ sh:inversePath <predicate> ], i.e. make it a complex path
   const query = `
     PREFIX form: <http://lblod.data.gift/vocabularies/forms/>
     PREFIX sh: <http://www.w3.org/ns/shacl#>
@@ -159,6 +162,8 @@ const getPathTails = async function (fieldWhere: string, formStore: N3.Store) {
 /**
  * Were are combining 3 different queries. This is to avoid a bug in the union implementation of comunica.
  * This only works because comunica uses consistent blank node identifiers across queries.
+ *
+ * NOTE: we currently only support direct fields in generator shapes, not complex paths
  *
  * here,
  * - step is the current step in the path (blank node) (or if a simple path, the predicate)

--- a/utils.ts
+++ b/utils.ts
@@ -57,3 +57,8 @@ export const ttlToStore = function (ttl: string): Promise<N3.Store> {
     });
   });
 };
+
+export const modifierLookup = {
+  // only inverse path is supported for now
+  'http://www.w3.org/ns/shacl#inversePath': '^',
+};


### PR DESCRIPTION
This creates a construct query to fetch information necessary to render an instance of a form definition.

That construct query can then be used for:
- fetching all data for a form from a mu-auth aware triple store (SEAS)
- fetching only the form data from a form instance posted by the frontend
- deleting all form data from the backend and replacing it with the new form content (this is a little hardcore, we may want to be nicer and only replace the delta)