### PR TITLE
update instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,38 @@ docker run --rm -it -p 9229:9229 -p 8081:80 -e NODE_ENV=development local-form-m
 ```
 
 Running it in development mode and exposing port 9229 allows you to connect your debugger to the docker.
+
+## Limitations
+
+### No Generator Shape Paths
+
+Currently, this service only supports generators with simple paths in their shape, e.g.
+
+```
+ext:mandatarisG a form:Generator;
+  form:prototype [
+    form:shape [
+      a ns:Mandataris
+    ]
+  ];
+  form:dataGenerator form:addMuUuid.
+```
+
+This generator's shape only has direct attributes (a ns:Mandataris) without modifiers, like sh:inversePath. Anything more complicated will not be handled by this service yet.
+
+For instance, this shape is **not supported**:
+
+```
+ext:mandatarisG a form:Generator;
+  form:prototype [
+    form:shape [
+      a ns:Mandataris
+      mandaat:isBestuurlijkeAliasVan / foaf:name "De Grote Smurf"
+    ]
+  ];
+  form:dataGenerator form:addMuUuid.
+```
+
+### No Modified Simple Paths in fields or generator scopes
+
+Fields and Generators can each define a scope. This service supports simple paths (e.g. `foaf:name`) and complex paths (e.g. `( [ sh:inversePath mandaat:isAangesteldAls ] foaf:name )`). However, modified simple paths are **not supported** (e.g. `[ sh:inversePath mandaat:isAangesteldAls ]`). Luckily, these can always be written in their complex form, which IS supported: `( [ sh:inversePath mandaat:isAangesteldAls ] )` (note the wrapping brackets in this case, signifying a linked list in RDF).

--- a/app.ts
+++ b/app.ts
@@ -7,7 +7,6 @@ import {
 } from './form-repository';
 import { cleanAndValidateFormInstance } from './form-validator';
 import { HttpError, fetchInstanceIdByUri, ttlToInsert } from './utils';
-import { FormDefinition } from './types';
 
 loadFormsFromConfig();
 

--- a/form-repository.ts
+++ b/form-repository.ts
@@ -137,10 +137,14 @@ export const computeInstanceDeltaQuery = async function (
 
   const remove = `
   DELETE DATA {
-    ${removed.map((quad) => quadToString(quad)).join('\n')}
-  }`;
-  const insert = `INSERT DATA {
-    ${added.map((quad) => quadToString(quad)).join('\n')}
+    GRAPH <http://mu.semte.ch/graphs/application> {
+      ${removed.map((quad) => quadToString(quad)).join('\n')}
+    }
+  };`;
+  const insert = `\nINSERT DATA {
+    GRAPH <http://mu.semte.ch/graphs/application> {
+      ${added.map((quad) => quadToString(quad)).join('\n')}
+    }
   }`;
 
   let query = '';

--- a/form-validator.ts
+++ b/form-validator.ts
@@ -130,7 +130,7 @@ const extractFormDataTtl = async function (
   dataTtl: string,
   formTtl: string,
   instanceUri: string,
-) {
+): Promise<string> {
   const constructQuery = await buildFormConstructQuery(formTtl, instanceUri);
   const constructStore = await ttlToStore(dataTtl);
   const engine = new QueryEngine();


### PR DESCRIPTION
This allows a form instance to be updated. The service will do a comparison of the existing data and the data coming from the form and only insert/remove the changed triples.

e.g. from the logs of the service:

```
  DELETE DATA {
    GRAPH <http://mu.semte.ch/graphs/application> {
      <http://data.lblod.info/form-data/instances/c34414a8-8425-41b9-bd6f-64bdd4ba0b5d> <http://data.vlaanderen.be/ns/mandaat#start> "2001-01-01T00:00:00.000Z"^^xsd:dateTime .
<http://data.lblod.info/form-data/instances/c34414a8-8425-41b9-bd6f-64bdd4ba0b5d> <http://data.vlaanderen.be/ns/mandaat#rangorde> """test""" .
    }
  };
INSERT DATA {
    GRAPH <http://mu.semte.ch/graphs/application> {
      <http://data.lblod.info/form-data/instances/c34414a8-8425-41b9-bd6f-64bdd4ba0b5d> <http://data.vlaanderen.be/ns/mandaat#rangorde> """testing""" .
<http://data.lblod.info/form-data/instances/c34414a8-8425-41b9-bd6f-64bdd4ba0b5d> <http://data.vlaanderen.be/ns/mandaat#start> "2002-01-01T00:00:00.000Z"^^xsd:dateTime .
    }
  }
```
when the rangorde and the start date were updated. Other fields remain unchanged.