### PR TITLE
fix delete failing for instances of a form without type generator

### DIFF
--- a/controllers/form-instances.ts
+++ b/controllers/form-instances.ts
@@ -56,8 +56,8 @@ formInstanceRouter.put(
 formInstanceRouter.delete(
   '/:id/instances/:instanceId',
   async (req: Request, res: Response) => {
-    deleteFormInstance(req.params.id, req.params.instanceId);
-    res.send(200);
+    await deleteFormInstance(req.params.id, req.params.instanceId);
+    res.sendStatus(200);
   },
 );
 

--- a/form-validator.ts
+++ b/form-validator.ts
@@ -145,10 +145,12 @@ export const buildFormQuery = async function (
     PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
     ${options?.afterPrefixesSnippet || ''}
     ${queryType} {
+      <${instanceUri}> a ?type .
       ${constructVariables.join('\n')}
     }
     ${options?.beforeWhereSnippet || ''}
     WHERE {
+      <${instanceUri}> a ?type .
       ${constructPaths.join('\n')}
     }
   `;


### PR DESCRIPTION
always ask for the types of the form instance so that we can erect a tombstone
fix missing await in delete controller, which could make the service crash if the delete fails (unhandled promise rejection)