### PR TITLE
Ben/lmb 254 fallback history

### DIFF
--- a/domain/data-access/form-repository.ts
+++ b/domain/data-access/form-repository.ts
@@ -448,6 +448,22 @@ const getHistoryInstance = async (historyUri: string) => {
   return unsecureGetHistoryInstance(historyUri);
 };
 
+const hasHistoryItems = async (instanceId: string) => {
+  const result = await querySudo(`
+    PREFIX dct: <http://purl.org/dc/terms/>
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+
+    ASK {
+      ?instance mu:uuid ${sparqlEscapeString(instanceId)} .
+      GRAPH <http://mu.semte.ch/graphs/formHistory> {
+        ?history dct:isVersionOf ?instance .
+      }
+    }
+  `);
+
+  return result.boolean;
+};
+
 export default {
   addFormInstance,
   deleteFormInstance,
@@ -462,4 +478,5 @@ export default {
   getInstanceHistoryWithCount,
   saveInstanceVersion,
   updateFormInstance,
+  hasHistoryItems,
 };

--- a/services/form-instances.ts
+++ b/services/form-instances.ts
@@ -169,13 +169,12 @@ export const updateFormInstance = async (
     comunicaRepo.getFormData(form.formTtl),
   ]);
 
-  const hasHistory = await formRepo.hasHistoryItems(instanceId);
-  if (formData.withHistory && !hasHistory) {
+  if (formData.withHistory && !(await formRepo.hasHistoryItems(instanceId))) {
     await formRepo.saveInstanceVersion(
       instance.instanceUri,
       instance.formInstanceTtl,
       userId,
-      'Original verion',
+      'Originele versie',
     );
   }
 

--- a/services/form-instances.ts
+++ b/services/form-instances.ts
@@ -169,9 +169,8 @@ export const updateFormInstance = async (
     comunicaRepo.getFormData(form.formTtl),
   ]);
 
-  // Write history of previous state
-  // TODO this only needs to be done when there is no history yet
-  if (formData.withHistory) {
+  const hasHistory = await formRepo.hasHistoryItems(instanceId);
+  if (formData.withHistory && !hasHistory) {
     await formRepo.saveInstanceVersion(
       instance.instanceUri,
       instance.formInstanceTtl,

--- a/services/form-instances.ts
+++ b/services/form-instances.ts
@@ -169,6 +169,17 @@ export const updateFormInstance = async (
     comunicaRepo.getFormData(form.formTtl),
   ]);
 
+  // Write history of previous state
+  // TODO this only needs to be done when there is no history yet
+  if (formData.withHistory) {
+    await formRepo.saveInstanceVersion(
+      instance.instanceUri,
+      instance.formInstanceTtl,
+      userId,
+      'Original verion',
+    );
+  }
+
   await formRepo.updateFormInstance(instance, validatedContentTtl);
 
   const newInstance = await fetchFormInstanceById(form, instanceId);


### PR DESCRIPTION
Add fallback history when updating form instances which already existed before the introduction of form history.