### PR TITLE
LMB-370: dct:modified to every instance that is being updated

### DIFF
--- a/form-validator.ts
+++ b/form-validator.ts
@@ -170,12 +170,16 @@ export const buildFormQuery = async function (
     ${options?.afterPrefixesSnippet || ''}
     ${queryType} {
       <${instanceUri}> a ?type .
+      <${instanceUri}> <http://purl.org/dc/terms/modified> ?modifiedAt .
       ${constructVariables.join('\n')}
     }
     ${options?.beforeWhereSnippet || ''}
     WHERE {
       <${instanceUri}> a ?type .
       OPTIONAL {
+        OPTIONAL {
+          <${instanceUri}> <http://purl.org/dc/terms/modified> ?modifiedAt .
+        }
         ${constructPaths.join('\n')}
       }
     }

--- a/form-validator.ts
+++ b/form-validator.ts
@@ -8,8 +8,8 @@ import { getPathsForFieldsQuery } from './domain/data-access/getPathsForFields';
 import { getPathsForGeneratorQuery } from './domain/data-access/getPathsForGenerators';
 import { ttlToStore } from './helpers/ttl-helpers';
 import {
-  XSD_TYPES,
-  PREDICATES,
+  DATATYPE,
+  PREDICATE,
   updatePredicateInTtl,
 } from './utils/update-predicate-in-ttl';
 
@@ -221,8 +221,8 @@ export const cleanAndValidateFormInstance = async function (
   const parsedTtl = await store.serializeDataMergedGraph(validationGraph);
   const updatedModifiedAt = await updatePredicateInTtl(
     new NamedNode(instanceUri),
-    PREDICATES.modified,
-    new Literal(new Date().toString(), undefined, XSD_TYPES.datetime),
+    PREDICATE.modified,
+    new Literal(new Date().toString(), undefined, DATATYPE.datetime),
     parsedTtl,
   );
 

--- a/form-validator.ts
+++ b/form-validator.ts
@@ -170,7 +170,7 @@ export const buildFormQuery = async function (
     ${options?.afterPrefixesSnippet || ''}
     ${queryType} {
       <${instanceUri}> a ?type .
-      <${instanceUri}> <http://purl.org/dc/terms/modified> ?modifiedAt .
+      <${instanceUri}> <${PREDICATE.modified.value}> ?modifiedAt .
       ${constructVariables.join('\n')}
     }
     ${options?.beforeWhereSnippet || ''}
@@ -178,7 +178,7 @@ export const buildFormQuery = async function (
       <${instanceUri}> a ?type .
       OPTIONAL {
         OPTIONAL {
-          <${instanceUri}> <http://purl.org/dc/terms/modified> ?modifiedAt .
+          <${instanceUri}> <${PREDICATE.modified.value}> ?modifiedAt .
         }
         ${constructPaths.join('\n')}
       }

--- a/form-validator.ts
+++ b/form-validator.ts
@@ -219,7 +219,7 @@ export const cleanAndValidateFormInstance = async function (
   await store.parse(instanceTtl, validationGraph);
 
   const parsedTtl = await store.serializeDataMergedGraph(validationGraph);
-  const updatedModifiedAt = await updatePredicateInTtl(
+  const ttlWithModifiedAt = await updatePredicateInTtl(
     new NamedNode(instanceUri),
     PREDICATE.modified,
     new Literal(new Date().toString(), undefined, DATATYPE.datetime),
@@ -227,7 +227,7 @@ export const cleanAndValidateFormInstance = async function (
   );
 
   const cleanedTtl = await extractFormDataTtl(
-    updatedModifiedAt,
+    ttlWithModifiedAt,
     definitionTtl,
     instanceUri,
   );

--- a/form-validator.ts
+++ b/form-validator.ts
@@ -7,7 +7,11 @@ import N3 from 'n3';
 import { getPathsForFieldsQuery } from './domain/data-access/getPathsForFields';
 import { getPathsForGeneratorQuery } from './domain/data-access/getPathsForGenerators';
 import { ttlToStore } from './helpers/ttl-helpers';
-import { XSD_TYPES, PREDICATES, updatePredicateInTtl } from './utils/update-predicate-in-ttl';
+import {
+  XSD_TYPES,
+  PREDICATES,
+  updatePredicateInTtl,
+} from './utils/update-predicate-in-ttl';
 
 type PathSegment = { predicate?: string; step?: string };
 type PathQueryResultItem = PathSegment & { previous?: string; field: string };
@@ -214,8 +218,8 @@ export const cleanAndValidateFormInstance = async function (
   const updatedModifiedAt = await updatePredicateInTtl(
     new NamedNode(instanceUri),
     PREDICATES.modified,
-    new Literal(new Date().toString(), XSD_TYPES.datetime),
-    parsedTtl
+    new Literal(new Date().toString(), undefined, XSD_TYPES.datetime),
+    parsedTtl,
   );
 
   const cleanedTtl = await extractFormDataTtl(

--- a/utils/update-predicate-in-ttl.ts
+++ b/utils/update-predicate-in-ttl.ts
@@ -1,35 +1,39 @@
 import ForkingStore from 'forking-store';
-import { NamedNode, Namespace, Statement, Literal } from 'rdflib';
-
-const DCT = new Namespace('http://purl.org/dc/terms/');
-const XSD = new Namespace('http://www.w3.org/2001/XMLSchema#');
+import { NamedNode, Statement, Literal } from 'rdflib';
 
 export const PREDICATES = {
-  modified: DCT('modified')
-}
+  modified: new NamedNode('http://purl.org/dc/terms/modified'),
+};
+
 export const XSD_TYPES = {
-  datetime: XSD('datetime')
-}
+  datetime: new NamedNode('http://www.w3.org/2001/XMLSchema#datetime'),
+};
 
 export const updatePredicateInTtl = async (
   instance: NamedNode,
-  predicate: Namespace,
+  predicate: NamedNode,
   predicatevalue: Literal,
-  ttlCode: string
+  ttlCode: string,
 ) => {
   const store = new ForkingStore();
   const sourceGraph = new NamedNode('http://data.lblod.info/sourceGraph');
   store.parse(ttlCode, sourceGraph, 'text/turtle');
 
-  const currentMatches = store.match(instance, predicate, undefined, sourceGraph);
+  const currentMatches = store.match(
+    instance,
+    predicate,
+    undefined,
+    sourceGraph,
+  );
   store.removeStatements(currentMatches);
 
   const statement = new Statement(
     instance,
     predicate,
     predicatevalue,
-    sourceGraph
-  )
-  store.addAll([statement])
+    sourceGraph,
+  );
+  store.addAll([statement]);
+
   return await store.serializeDataMergedGraph(sourceGraph);
-}
+};

--- a/utils/update-predicate-in-ttl.ts
+++ b/utils/update-predicate-in-ttl.ts
@@ -1,11 +1,11 @@
 import ForkingStore from 'forking-store';
 import { NamedNode, Statement, Literal } from 'rdflib';
 
-export const PREDICATES = {
+export const PREDICATE = {
   modified: new NamedNode('http://purl.org/dc/terms/modified'),
 };
 
-export const XSD_TYPES = {
+export const DATATYPE = {
   datetime: new NamedNode('http://www.w3.org/2001/XMLSchema#datetime'),
 };
 

--- a/utils/update-predicate-in-ttl.ts
+++ b/utils/update-predicate-in-ttl.ts
@@ -1,0 +1,35 @@
+import ForkingStore from 'forking-store';
+import { NamedNode, Namespace, Statement, Literal } from 'rdflib';
+
+const DCT = new Namespace('http://purl.org/dc/terms/');
+const XSD = new Namespace('http://www.w3.org/2001/XMLSchema#');
+
+export const PREDICATES = {
+  modified: DCT('modified')
+}
+export const XSD_TYPES = {
+  datetime: XSD('datetime')
+}
+
+export const updatePredicateInTtl = async (
+  instance: NamedNode,
+  predicate: Namespace,
+  predicatevalue: Literal,
+  ttlCode: string
+) => {
+  const store = new ForkingStore();
+  const sourceGraph = new NamedNode('http://data.lblod.info/sourceGraph');
+  store.parse(ttlCode, sourceGraph, 'text/turtle');
+
+  const currentMatches = store.match(instance, predicate, undefined, sourceGraph);
+  store.removeStatements(currentMatches);
+
+  const statement = new Statement(
+    instance,
+    predicate,
+    predicatevalue,
+    sourceGraph
+  )
+  store.addAll([statement])
+  return await store.serializeDataMergedGraph(sourceGraph);
+}


### PR DESCRIPTION
LMB-370

## Description

We are adding a predicate dct:modified to each subject that is being updated through the form-content-service. This so we do not have to add hidden fields to each entity in the backend and so that we can have always see when an entity is modified.

## Test
In the predicates of each subject that you update through a form should be the dct:modified with the datetime of the change 