### PR TITLE
Ben/lmb 352 form instances search

### DIFF
--- a/controllers/form-instances.ts
+++ b/controllers/form-instances.ts
@@ -26,10 +26,12 @@ formInstanceRouter.get(
     const limit = parseInt(req.query.page?.size || 10, 10);
     const offset = parseInt(req.query.page?.number || 0, 10) * limit;
     const sort = req.query.sort;
+    const filter = req.query.filter;
     const formInstances = await getInstancesForForm(req.params.formId, {
       limit,
       offset,
       sort,
+      filter,
     });
     res.set('X-Total-Count', formInstances.count);
     res.send({ instances: formInstances.instances });

--- a/controllers/form-instances.ts
+++ b/controllers/form-instances.ts
@@ -25,9 +25,11 @@ formInstanceRouter.get(
   async (req: Request, res: Response) => {
     const limit = parseInt(req.query.page?.size || 10, 10);
     const offset = parseInt(req.query.page?.number || 0, 10) * limit;
+    const sort = req.query.sort;
     const formInstances = await getInstancesForForm(req.params.formId, {
       limit,
       offset,
+      sort,
     });
     res.set('X-Total-Count', formInstances.count);
     res.send({ instances: formInstances.instances });

--- a/domain/data-access/comunica-repository.ts
+++ b/domain/data-access/comunica-repository.ts
@@ -100,9 +100,10 @@ export const getFormLabels = async (formTtl: string): Promise<Label[]> => {
 
   const labels = bindings.map((binding) => {
     return {
-      // Remove all spaces from this string,
+      // Remove all spaces from this string, and transform the string to lowercase
       // as this is used as key in a later stage, which can't contain spaces.
-      name: binding.get('labelName')?.value.replace(/ /g, '') ?? '',
+      name:
+        binding.get('labelName')?.value.replace(/ /g, '')?.toLowerCase() ?? '',
       uri: binding.get('labelUri')?.value ?? '',
     };
   });

--- a/domain/data-access/form-repository.ts
+++ b/domain/data-access/form-repository.ts
@@ -182,7 +182,7 @@ const getFormInstanceCount = async (targetType: string) => {
 const getFormInstances = async (
   targetType: string,
   labels: Label[],
-  options?: { limit?: number; offset?: number },
+  options?: { limit?: number; offset?: number; sort?: string },
 ) => {
   const labelJoin = labels
     .map((label) => {
@@ -191,6 +191,9 @@ const getFormInstances = async (
     .join('\n');
   const defaultPageSize = 20;
   const defaultOffset = 0;
+  const order = options?.sort?.charAt(0) == '-' ? 'DESC' : 'ASC';
+  const sortName =
+    order == 'DESC' ? options?.sort?.substring(1) : options?.sort;
   const q = `
     PREFIX inst: <http://data.lblod.info/form-data/instances/>
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
@@ -201,7 +204,8 @@ const getFormInstances = async (
         OPTIONAL { ${labelJoin} }
         ?uri mu:uuid ?id .
     }
-    ORDER BY ?uri LIMIT ${options?.limit || defaultPageSize}
+    ORDER BY ${order}(?${sortName ? sortName : 'uri'})
+    LIMIT ${options?.limit || defaultPageSize}
     OFFSET ${options?.offset || defaultOffset}
     `;
 
@@ -228,7 +232,7 @@ const getFormInstances = async (
 const getFormInstancesWithCount = async (
   targetType: string,
   labels: Label[],
-  options?: { limit?: number; offset?: number },
+  options?: { limit?: number; offset?: number; sort?: string },
 ) => {
   const [instances, count] = await Promise.all([
     getFormInstances(targetType, labels, options),

--- a/domain/data-access/form-repository.ts
+++ b/domain/data-access/form-repository.ts
@@ -167,6 +167,9 @@ const getFormInstanceCount = async (
   targetType: string,
   options?: { limit?: number; offset?: number; sort?: string; filter?: string },
 ) => {
+  const filter = options?.filter
+    ? `FILTER CONTAINS(LCASE(str(?o)), LCASE("${options?.filter}"))`
+    : '';
   const q = `
     PREFIX inst: <http://data.lblod.info/form-data/instances/>
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
@@ -176,7 +179,7 @@ const getFormInstanceCount = async (
         ?uri a ${sparqlEscapeUri(targetType)} .
         ?uri mu:uuid ?id .
         ?uri ?p ?o .
-        ${options?.filter ? `FILTER regex(?o, "${options?.filter}", "i")` : ''}
+        ${filter}
     }`;
 
   const queryResult = await query(q);
@@ -206,6 +209,9 @@ const getFormInstances = async (
   const order = options?.sort?.charAt(0) == '-' ? 'DESC' : 'ASC';
   const sortName =
     order == 'DESC' ? options?.sort?.substring(1) : options?.sort;
+  const filter = options?.filter
+    ? `FILTER CONTAINS(LCASE(str(?o)), LCASE("${options?.filter}"))`
+    : '';
   const q = `
     PREFIX inst: <http://data.lblod.info/form-data/instances/>
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
@@ -216,7 +222,7 @@ const getFormInstances = async (
         OPTIONAL { ${labelJoin} }
         ?uri mu:uuid ?id .
         ?uri ?p ?o .
-        ${options?.filter ? `FILTER regex(?o, "${options?.filter}", "i")` : ''}
+        ${filter}
     }
     ORDER BY ${order}(?${sortName ? sortName : 'uri'})
     LIMIT ${options?.limit || defaultPageSize}

--- a/domain/data-access/form-repository.ts
+++ b/domain/data-access/form-repository.ts
@@ -163,7 +163,10 @@ const deleteFormInstance = async (formTtl: string, instanceUri: string) => {
   await query(q);
 };
 
-const getFormInstanceCount = async (targetType: string) => {
+const getFormInstanceCount = async (
+  targetType: string,
+  options?: { limit?: number; offset?: number; sort?: string; filter?: string },
+) => {
   const q = `
     PREFIX inst: <http://data.lblod.info/form-data/instances/>
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
@@ -172,6 +175,8 @@ const getFormInstanceCount = async (targetType: string) => {
     WHERE {
         ?uri a ${sparqlEscapeUri(targetType)} .
         ?uri mu:uuid ?id .
+        ?uri ?p ?o .
+        ${options?.filter ? `FILTER regex(?o, "${options?.filter}", "i")` : ''}
     }`;
 
   const queryResult = await query(q);
@@ -245,7 +250,7 @@ const getFormInstancesWithCount = async (
 ) => {
   const [instances, count] = await Promise.all([
     getFormInstances(targetType, labels, options),
-    getFormInstanceCount(targetType),
+    getFormInstanceCount(targetType, options),
   ]);
 
   return { instances, count };

--- a/services/form-instances.ts
+++ b/services/form-instances.ts
@@ -55,7 +55,7 @@ export const postFormInstance = async (
 
 export const getInstancesForForm = async (
   formId: string,
-  options?: { limit?: number; offset?: number; sort?: string },
+  options?: { limit?: number; offset?: number; sort?: string; filter?: string },
 ) => {
   const form = await fetchFormDefinitionById(formId);
   if (!form) {

--- a/services/form-instances.ts
+++ b/services/form-instances.ts
@@ -55,7 +55,7 @@ export const postFormInstance = async (
 
 export const getInstancesForForm = async (
   formId: string,
-  options: { limit: number; offset: number },
+  options?: { limit?: number; offset?: number; sort?: string },
 ) => {
   const form = await fetchFormDefinitionById(formId);
   if (!form) {


### PR DESCRIPTION
## Description

Add possibility to sort instances result and to filter. Requests have the following format: `http://localhost:4200/form-content/persoon/instances?page[size]=10&page[number]=3&sort=voornaam&filter=ae`

## Testing

This can easily be tested with the corresponding frontend: https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/176