### PR TITLE
LMB-370: dct:modified bug resolve resource can't read type datetime

### DIFF
--- a/helpers/ttl-helpers.ts
+++ b/helpers/ttl-helpers.ts
@@ -6,6 +6,7 @@ const parser = new N3.Parser();
 
 const datatypeNames = {
   'http://www.w3.org/2001/XMLSchema#dateTime': 'dateTime',
+  'http://www.w3.org/2001/XMLSchema#datetime': 'dateTime',
   'http://www.w3.org/2001/XMLSchema#date': 'date',
   'http://www.w3.org/2001/XMLSchema#decimal': 'decimal',
   'http://www.w3.org/2001/XMLSchema#integer': 'int',

--- a/utils/update-predicate-in-ttl.ts
+++ b/utils/update-predicate-in-ttl.ts
@@ -6,7 +6,7 @@ export const PREDICATE = {
 };
 
 export const DATATYPE = {
-  datetime: new NamedNode('http://www.w3.org/2001/XMLSchema#datetime'),
+  datetime: new NamedNode('http://www.w3.org/2001/XMLSchema#dateTime'),
 };
 
 export const updatePredicateInTtl = async (


### PR DESCRIPTION
Issue: LMB-370
Description: When creating or updating the type of dct:modified is incorrect. What we used is **datetime** what it should be **dateTime**. The difference is the capital T in the type.

When datetime is used the helpers will return the dateTime type how it supposed to be.