### PR TITLE
Log Clear Errors When Invalid Forms Are Loaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ docker run --rm -it -p 9229:9229 -p 8081:80 -e NODE_ENV=development local-form-m
 
 Running it in development mode and exposing port 9229 allows you to connect your debugger to the docker.
 
+### Project Structure
+
+The project follows the Model-view-controller (MVC) architecture.
+
+- Routing and anything Express related resides in `/controllers`. The routes should be simple methods that call services.
+- Services reside in `/services`. This is where the business logic and validations are.
+- Querries for the database or Comunica go in `/domain/data-access`. These query methods should only contain the means to query or mutate the data, and return the result in a format that the service understands.
+- Helpers reside in `/helpers` and contain functionality that is used in multiple services or querries.
+
 ## Model
 
 This service follows the semantic forms model and to that end uses the ember-submission-form-fields package. However, some extensions are needed and they may not have made it into the form spec yet. The main extensions are: listing form instance, defining the uri prefix for form instances, linking to other types (possibly forms) using dropdowns etc.
@@ -216,3 +225,7 @@ ext:mandatarisG a form:Generator;
 ### No Modified Simple Paths in fields or generator scopes
 
 Fields and Generators can each define a scope. This service supports simple paths (e.g. `foaf:name`) and complex paths (e.g. `( [ sh:inversePath mandaat:isAangesteldAls ] foaf:name )`). However, modified simple paths are **not supported** (e.g. `[ sh:inversePath mandaat:isAangesteldAls ]`). Luckily, these can always be written in their complex form, which IS supported: `( [ sh:inversePath mandaat:isAangesteldAls ] )` (note the wrapping brackets in this case, signifying a linked list in RDF).
+
+### Lenient Form Validity Checks
+
+The validity of all forms is checked at startup, but the parsing library that we currently use (N3) is lenient and will sometimes still parse a form, even if it uses unknown prefixes. Therefore the full validity of the forms at runtime cannot be guaranteed, they just pass through a best effort check.

--- a/controllers/form-definitions.ts
+++ b/controllers/form-definitions.ts
@@ -1,12 +1,12 @@
 import { Request, Response } from 'express';
 import { fetchFormDefinition } from '../services/form-definitions';
-import { fetchFormDirectories } from '../services/forms-from-config';
+import { fetchFormDirectoryNames } from '../services/forms-from-config';
 import Router from 'express-promise-router';
 
 const formDefinitionRouter = Router();
 
 formDefinitionRouter.get('/forms', async (_req: Request, res: Response) => {
-  const formDirectories = await fetchFormDirectories();
+  const formDirectories = await fetchFormDirectoryNames();
   res.send({ formDirectories });
 });
 

--- a/domain/data-access/comunica-repository.ts
+++ b/domain/data-access/comunica-repository.ts
@@ -162,10 +162,32 @@ const getUriTypes = async (ttl: string) => {
     .filter((binding) => binding !== null) as { uri: string; type: string }[];
 };
 
+/*
+ * Best effort check to see if the form is valid
+ * The N3 parser is lenient and will sometimes still parse a form, even if it uses unknown prefixes.
+ */
+const isValidForm = async (formTtl: string) => {
+  const query = `
+  PREFIX form:  <http://lblod.data.gift/vocabularies/forms/>
+
+  ASK { 
+    ?s a ?o.
+    VALUES ?o { form:Form form:Extension }
+  }`;
+  const store = await ttlToStore(formTtl);
+  const engine = new QueryEngine();
+  const hasMatches = await engine.queryBoolean(query, {
+    sources: [store],
+  });
+
+  return hasMatches;
+};
+
 export default {
   getFormData,
   getFormTarget,
   getFormLabels,
   fetchConceptSchemeUris,
   getUriTypes,
+  isValidForm,
 };

--- a/domain/data-access/form-extension-repository.ts
+++ b/domain/data-access/form-extension-repository.ts
@@ -20,17 +20,6 @@ const isFormExtension = async (formTtl: string) => {
   return hasMatches;
 };
 
-const isValidForm = async (formTtl: string) => {
-  const query = 'ASK { ?s ?p ?o. }';
-  const store = await ttlToStore(formTtl);
-  const engine = new QueryEngine();
-  const hasMatches = await engine.queryBoolean(query, {
-    sources: [store],
-  });
-
-  return hasMatches;
-};
-
 const getBaseFormUri = async (formTtl: string) => {
   const query = `
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
@@ -276,7 +265,6 @@ const deleteAllFromBaseForm = async (
 
 export default {
   isFormExtension,
-  isValidForm,
   getBaseFormUri,
   getFormUri,
   getFormId,

--- a/domain/data-access/form-extension-repository.ts
+++ b/domain/data-access/form-extension-repository.ts
@@ -20,6 +20,17 @@ const isFormExtension = async (formTtl: string) => {
   return hasMatches;
 };
 
+const isValidForm = async (formTtl: string) => {
+  const query = 'ASK { ?s ?p ?o. }';
+  const store = await ttlToStore(formTtl);
+  const engine = new QueryEngine();
+  const hasMatches = await engine.queryBoolean(query, {
+    sources: [store],
+  });
+
+  return hasMatches;
+};
+
 const getBaseFormUri = async (formTtl: string) => {
   const query = `
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
@@ -79,7 +90,7 @@ const getFormUri = async (formTtl: string) => {
   return binding.value;
 };
 
-const getFormId = async (formTtl: string) => {
+const getFormId = async (formTtl: string): Promise<string> => {
   const query = `
     PREFIX form: <http://lblod.data.gift/vocabularies/forms/>
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
@@ -265,6 +276,7 @@ const deleteAllFromBaseForm = async (
 
 export default {
   isFormExtension,
+  isValidForm,
   getBaseFormUri,
   getFormUri,
   getFormId,

--- a/services/forms-from-config.ts
+++ b/services/forms-from-config.ts
@@ -108,31 +108,35 @@ const loadConfigForm = async (formName: string) => {
   }
 };
 
-const delay = (ms) => new Promise((res) => setTimeout(res, ms));
-
-// add if check: hasInvalidForm
-// assign true to hasInvalidForm if form is invalid
-// if hasInvalidForm is true, if true, throw error that you should read the logs
 export const loadFormsFromConfig = async () => {
   const formDirectoryNames = await fetchFormDirectoryNames();
-  //await delay(5000);
+
+  let hasInvalidForm = false;
 
   for (const formDirectoryName of formDirectoryNames) {
     const formDefinition = await loadConfigForm(formDirectoryName);
     if (!formDefinition) {
-      return;
+      hasInvalidForm = true;
+      continue;
     }
-    const isValidForm = await formExtRepo.isValidForm(formDefinition.formTtl);
+    const isValidForm = await comunicaRepo.isValidForm(formDefinition.formTtl);
     if (!isValidForm) {
       console.error(
-        `The ${formDirectoryName} form is invalid. Check if the form.ttl is correct and all prefixes are defined.`,
+        `Error: The ${formDirectoryName} form is invalid. Check if the form.ttl is correct and all prefixes are defined.`,
       );
-      return;
+      hasInvalidForm = true;
+      continue;
     }
 
     formsFromConfig[formDirectoryName] = formDefinition;
     const formUri = await formExtRepo.getFormUri(formDefinition.formTtl);
     formsUriToId[formUri] = formDirectoryName;
+  }
+
+  if (hasInvalidForm) {
+    throw new Error(
+      'One or more forms are invalid. Check the logs for more information.',
+    );
   }
 };
 

--- a/services/forms-from-config.ts
+++ b/services/forms-from-config.ts
@@ -110,6 +110,9 @@ const loadConfigForm = async (formName: string) => {
 
 const delay = (ms) => new Promise((res) => setTimeout(res, ms));
 
+// add if check: hasInvalidForm
+// assign true to hasInvalidForm if form is invalid
+// if hasInvalidForm is true, if true, throw error that you should read the logs
 export const loadFormsFromConfig = async () => {
   const formDirectoryNames = await fetchFormDirectoryNames();
   //await delay(5000);
@@ -122,7 +125,7 @@ export const loadFormsFromConfig = async () => {
     const isValidForm = await formExtRepo.isValidForm(formDefinition.formTtl);
     if (!isValidForm) {
       console.error(
-        `Form ${formDirectoryName} is not valid. Check if the form.ttl is correct and all prefixes are defined.`,
+        `The ${formDirectoryName} form is invalid. Check if the form.ttl is correct and all prefixes are defined.`,
       );
       return;
     }


### PR DESCRIPTION
## Description

I added a form validity check for all forms that are loaded into this service, so the service can fail early when an invalid form is loaded in. Before a hard to debug error was thrown when the request for all form names came in, giving the developer no leads on what form might be causing issues.

## How to test

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Kill the form-content-service
- Break one of the form.ttls in the backend by removing a prefix or a triple or the whole form.ttl altogether! ![image](https://github.com/lblod/form-content-service/assets/55446974/c859a0f5-f705-4c94-beda-0f926e8e2baa)
- Start the form-content-service
- After starting up, the service should crash. If you look at the logs you should see some descriptive errors of which form(s) are broken.
