### PR TITLE
Load forms into /config so they can be monitored by mu-javascript-template

### DIFF
--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -12,7 +12,7 @@ services:
       - '8081:80'
       - '9229:9229'
     volumes:
-      - ../app-lokaal-mandatenbeheer/config/form-content:/forms
+      - ../app-lokaal-mandatenbeheer/config/form-content:/config
       - ./:/app
       # ignore app/dist because this is where we map the built files to, otherwise we get an infinite loop of creating files (on mac)
       - /app/dist

--- a/services/forms-from-config.ts
+++ b/services/forms-from-config.ts
@@ -7,7 +7,7 @@ import { HttpError } from '../domain/http-error';
 import { extendForm } from './form-extensions';
 
 const formsFromConfig: FormsFromConfig = {};
-const formDirectory = '/forms';
+const formDirectory = '/config';
 
 const formsUriToId: UriToIdMap = {};
 


### PR DESCRIPTION
## Description

When changing form TTLs in `app-lokaal-mandatenbeheer`, the form-content-service didn't reload, and this lead to some confusion and inconvenience. With this PR, combined with a small change in the `mu-javascript-template`, the forms should update automatically without having to `kill` and `up` the form-content-service.

## How to test

- Start the `form-content-service`
- Go to the forms module in the browser and pick a form
- Change the formTTL of that form in `app` `/config/form-content`
- Check in the browser if the form has changed
