### PR TITLE
LMB-237: Extension forms should get the targetType and label from the base form

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ We want fields to be added to the original form in a specific order, intermixed 
 
 ### Extending the form with direct properties
 
-In an extension, we should be able to specify the same direct properties that we use in a regular form. In that case, we should define them on the `form:Extension`, instead of on the `form:Form`, using the same predicates as the ones used on the `form:Form`. The form-content service will take the `form:Extension` instance and transform it into a `form:Form` instance that contains the combination of the new properties and the properties that exist on the form that is being extended. The properties `form:targetType`, `form:targetLabel`, `ext:prefix` and `mu:uuid` are simply overwritten. So you should define them on the form extension. Other properties are taken from both, and are combined.
+In an extension, we should be able to specify the same direct properties that we use in a regular form. In that case, we should define them on the `form:Extension`, instead of on the `form:Form`, using the same predicates as the ones used on the `form:Form`. The form-content service will take the `form:Extension` instance and transform it into a `form:Form` instance that contains the combination of the new properties and the properties that exist on the form that is being extended. The properties `form:targetType`, `form:targetLabel` and `ext:prefix`, can be reconfigured, if they are defined in the form extension, this new value is used. If they are not defined in the extension, the ones value the base form is used. The property `mu:uuid` should be defined in the form extension and the old value overwritten. Other properties are taken from both, and are combined.
 
 ### Transparency of `form:Extension`s
 

--- a/domain/data-access/form-extension-repository.ts
+++ b/domain/data-access/form-extension-repository.ts
@@ -263,6 +263,28 @@ const deleteAllFromBaseForm = async (
   await engine.queryVoid(query, { sources: [store] });
 };
 
+const formExtensionHasPredicateSet = async (
+  predicate: string,
+  extensionFormTtl: string,
+) => {
+  const query = `
+  PREFIX form: <http://lblod.data.gift/vocabularies/forms/>
+  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+  ASK {
+    ?formUri a form:Extension.
+    ?formUri ${predicate} ?o.
+  }
+  `;
+
+  const store = await ttlToStore(extensionFormTtl);
+  const hasMatches = await engine.queryBoolean(query, {
+    sources: [store],
+  });
+
+  return hasMatches;
+};
+
 export default {
   isFormExtension,
   getBaseFormUri,
@@ -273,4 +295,5 @@ export default {
   replaceExtendsGroup,
   replaceFormUri,
   deleteAllFromBaseForm,
+  formExtensionHasPredicateSet,
 };

--- a/services/form-extensions.ts
+++ b/services/form-extensions.ts
@@ -28,8 +28,12 @@ export const extendForm = async (
   );
   await formExtRepo.loadTtlIntoGraph(extensionFormTtl, mergeGraph, store);
 
+  const predicatesToDeleteFromBase = await getDefinedPredicatesInExtensionForm(
+    extensionFormTtl,
+    ['form:targetType', 'form:targetLabel', 'ext:prefix'],
+  );
   await formExtRepo.deleteAllFromBaseForm(
-    ['form:targetLabel', 'ext:prefix', 'mu:uuid'],
+    [...predicatesToDeleteFromBase, 'mu:uuid'],
     mergeGraph,
     store,
   );
@@ -43,4 +47,23 @@ export const extendForm = async (
     formTtl: extendedFormTtl,
     metaTtl: baseFormDefinition.metaTtl,
   };
+};
+
+const getDefinedPredicatesInExtensionForm = async (
+  extensionFormTtl: string,
+  predicatesToCheck: Array<string>,
+) => {
+  const definedPredicates: Array<string> = [];
+
+  for (const predicate of predicatesToCheck) {
+    const isDefined = await formExtRepo.formExtensionHasPredicateSet(
+      predicate,
+      extensionFormTtl,
+    );
+    if (isDefined) {
+      definedPredicates.push(predicate);
+    }
+  }
+
+  return definedPredicates;
 };

--- a/services/form-extensions.ts
+++ b/services/form-extensions.ts
@@ -29,7 +29,7 @@ export const extendForm = async (
   await formExtRepo.loadTtlIntoGraph(extensionFormTtl, mergeGraph, store);
 
   await formExtRepo.deleteAllFromBaseForm(
-    ['form:targetType', 'form:targetLabel', 'ext:prefix', 'mu:uuid'],
+    ['form:targetLabel', 'ext:prefix', 'mu:uuid'],
     mergeGraph,
     store,
   );


### PR DESCRIPTION
## Description

It is possible to extend forms in the form-content service. E.g. forms bestuursorgaan-ext-example extend the form bestuursorgaan. The form-content merges these forms but if duplicate form settings (triples belonging to the form object) are deleted from the base form and taken from the extension. This is alright for the triples such as mu:uuid, but for other properties such as targetType, targetLabel and prefix it would be better if they were only overwritten if they exist in the form extension. 

This would mean they are no longer required, they are still required for a regular form, but if they are not defined in the form extension, the ones from the base form can just be used.
## How to test

- /

## How to test

- Remove for example the `form:targetType` from the [`bestuursorgaan-ext-example`](https://github.com/lblod/app-lokaal-mandatenbeheer/blob/master/config/form-content/bestuursorgaan-ext-example/form.ttl#L49) form and see that it is not being removed from the base form. You can check that by looking at the value of the array after `const predicatesToDeleteFromBase`  when debugging.