### PR TITLE
Add interceptor logic to allow custom conceptScheme fetching

### DIFF
--- a/config/interceptors.ts
+++ b/config/interceptors.ts
@@ -1,0 +1,17 @@
+// Override with your own file via volumes that has the same function signature.
+
+/* get the conceptSchemes referenced in a form and the already fetched triples as bindings with vars `s`, `p` and `o`:
+ * [  {
+ *   "s": { "type": "uri", "value": "..." },
+ *   "p": { "type": "uri", "value": "..." },
+ *   "o": { "type": "...", "value": "..." }
+ * }, { ... }  ]
+ *
+ * return adjusted list of triples (in same bindings format).
+ */
+export async function interceptorGetConceptSchemeTriples(
+  conceptSchemeUrisList,
+  fetchedSpoBindings,
+) {
+  return fetchedSpoBindings;
+}

--- a/domain/data-access/form-repository.ts
+++ b/domain/data-access/form-repository.ts
@@ -18,6 +18,7 @@ import {
 import { v4 as uuid } from 'uuid';
 import comunicaRepo from './comunica-repository';
 import { querySudo, updateSudo } from '@lblod/mu-auth-sudo';
+import { interceptorGetConceptSchemeTriples } from '../../config/interceptors';
 
 const fetchFormTtlById = async (formId: string): Promise<string | null> => {
   const result = await query(`
@@ -86,7 +87,12 @@ const bindingToTriple = (binding) =>
 const getConceptSchemeTriples = async (conceptSchemeUris: string[]) => {
   const constructQuery = buildConstructConceptSchemesQuery(conceptSchemeUris);
   const result = await query(constructQuery);
-  return result.results.bindings.map(bindingToTriple).join('\n');
+  let bindings = result.results.bindings;
+  bindings = await interceptorGetConceptSchemeTriples(
+    conceptSchemeUris,
+    bindings,
+  );
+  return bindings.map(bindingToTriple).join('\n');;
 };
 
 const fetchFormInstanceByUri = async (

--- a/domain/data-access/form-repository.ts
+++ b/domain/data-access/form-repository.ts
@@ -92,7 +92,7 @@ const getConceptSchemeTriples = async (conceptSchemeUris: string[]) => {
     conceptSchemeUris,
     bindings,
   );
-  return bindings.map(bindingToTriple).join('\n');;
+  return bindings.map(bindingToTriple).join('\n');
 };
 
 const fetchFormInstanceByUri = async (

--- a/services/forms-from-config.ts
+++ b/services/forms-from-config.ts
@@ -8,6 +8,8 @@ import { extendForm } from './form-extensions';
 
 const formsFromConfig: FormsFromConfig = {};
 const formDirectory = '/config';
+// This allows adding config files to the config folder that aren't forms.
+const nonFormConfigFiles = ['interceptors.ts'];
 
 const formsUriToId: UriToIdMap = {};
 
@@ -141,5 +143,7 @@ export const loadFormsFromConfig = async () => {
 };
 
 export const fetchFormDirectoryNames = async () => {
-  return await fs.readdir(formDirectory);
+  return (await fs.readdir(formDirectory)).filter(
+    (dir) => !nonFormConfigFiles.includes(dir),
+  );
 };


### PR DESCRIPTION
## Description
Add logic to allow adding a `interceptors.ts` file to the config that will get called when fetching conceptSchemes defined in the form. This allows populating dropdown fields (like `displayTypes:conceptSchemeSelector`) with any (possibly dynamic) data in the triplestore, without needing to make it an actual concept. It also allows filtering out conceptScheme triples that form-content-service fetched, giving extra flexibility.
If not defined, the interceptor does nothing, so this is a non-breaking change.

In the future it would be nice to force forms to be put in a subfolder (e.g. /forms) in the config directory, so other configurations can be added more easily.

It wasn't clear to me where in the Readme this should be explained.
## How to test
Create a form with some dropdown and a custom uri for the concept scheme. Code that will fill it with all `foaf:Person`s in the database as an example:

```
export async function interceptorGetConceptSchemeTriples(
  conceptSchemeUrisList,
  fetchedSpoBindings,
) {
  const conceptSchemeUri = "http://redpencil.data.gift/concept-schemes/CustomConceptPerson"
  if(conceptSchemeUrisList.includes(conceptSchemeUri)) {
    const result = await query(`
      PREFIX foaf: <http://xmlns.com/foaf/0.1/>
      SELECT DISTINCT ?uri ?name WHERE {
        ?uri a foaf:Person .
        ?uri foaf:name ?name .   }
    `);
    const concepts = result.results.bindings.map(({uri, name}) => ({uri: uri.value, label: name.value}))
    const conceptBindings = triplesForScheme({conceptSchemeUri, conceptSchemeLabel: "Persons", concepts})
    return fetchedSpoBindings.concat(conceptBindings);
  } else {
  return fetchedSpoBindings;  
}

function toSPO(s, p, o, typeO = "uri") {
  return {
    "s": { "type": "uri", "value": s },
    "p": { "type": "uri", "value": p },
    "o": { "type": typeO === "uri"? typeO : "literal", "value": o }
  }
}

function triplesForScheme({conceptSchemeUri, conceptSchemeLabel, concepts /* list of { uri, label }*/}) {
  const bindings = [
    toSPO(conceptSchemeUri, "http://www.w3.org/1999/02/22-rdf-syntax-ns#type", "http://www.w3.org/2004/02/skos/core#Concept"),
    toSPO(conceptSchemeUri, "skos:prefLabel", conceptSchemeLabel, "string")
  ]
  for(const {uri, label} of concepts) {
    bindings.push(toSPO(uri, "http://www.w3.org/1999/02/22-rdf-syntax-ns#type", "http://www.w3.org/2004/02/skos/core#Concept"))
    bindings.push(toSPO(uri, "http://www.w3.org/2004/02/skos/core#prefLabel", label, "string"))
    bindings.push(toSPO(uri, "http://www.w3.org/2004/02/skos/core#inScheme", conceptSchemeUri))
  }
  return bindings;
}
```