### PR TITLE
Workaround: adding the prefix xsd when returning the form and meta.

### DIFF
--- a/services/form-definitions.ts
+++ b/services/form-definitions.ts
@@ -8,8 +8,8 @@ export const fetchFormDefinition = async (id: string) => {
     formDefinition.formTtl,
   );
   return {
-    formTtl: formDefinition.formTtl,
-    metaTtl: formDefinition.metaTtl,
+    formTtl: `@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n${formDefinition.formTtl}`,
+    metaTtl: `@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n${formDefinition.metaTtl}`,
     prefix,
     withHistory,
   };


### PR DESCRIPTION
This is a similar strategy as what has been done in `getHistoryInstance`.
I am currently not sure what is to blame here,
i.e. who is not respecting a standard (js-template or rdfLib?)
