### PR TITLE
allow creating custom form extensions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,2 @@
-FROM local-js-template
-#FROM semtech/mu-javascript-template:1.8.0
+FROM semtech/mu-javascript-template:1.8.0
 LABEL maintainer="karel.kremer@redpencil.io"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,3 @@
-FROM semtech/mu-javascript-template:1.8.0
+FROM local-js-template
+#FROM semtech/mu-javascript-template:1.8.0
 LABEL maintainer="karel.kremer@redpencil.io"

--- a/app.ts
+++ b/app.ts
@@ -17,6 +17,8 @@ app.use('/', formDefinitionRouter);
 const errorHandler: ErrorRequestHandler = function (err, _req, res, _next) {
   // custom error handler to have a default 500 error code instead of 400 as in the template
   res.status(err.status || 500);
+  console.error(err);
+
   res.json({
     errors: [{ title: err.message }],
   });

--- a/controllers/form-definitions.ts
+++ b/controllers/form-definitions.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express';
 import { fetchFormDefinition } from '../services/form-definitions';
 import { fetchFormDirectoryNames } from '../services/forms-from-config';
 import Router from 'express-promise-router';
+import { addField } from '../services/custom-forms';
 
 const formDefinitionRouter = Router();
 
@@ -13,6 +14,23 @@ formDefinitionRouter.get('/forms', async (_req: Request, res: Response) => {
 formDefinitionRouter.get('/:id', async (req: Request, res: Response) => {
   const definition = await fetchFormDefinition(req.params.id);
   res.send(definition);
+});
+
+formDefinitionRouter.post(
+  '/:id/fields',
+  async (req: Request, res: Response) => {
+    const body = req.body;
+    const newFormData = await addField(req.params.id, body);
+    res.send(newFormData);
+  },
+);
+
+// this is in semantic forms territory and there we only know uris... we can solve this with contexts if necessary
+formDefinitionRouter.delete('/fields', async (req: Request, res: Response) => {
+  const formUri = req.body.formUri;
+  const fieldUri = req.body.fieldUri;
+  console.log(`deleting field ${formUri} ${fieldUri}`);
+  res.send({ success: true });
 });
 
 export { formDefinitionRouter };

--- a/controllers/form-definitions.ts
+++ b/controllers/form-definitions.ts
@@ -2,7 +2,7 @@ import { Request, Response } from 'express';
 import { fetchFormDefinition } from '../services/form-definitions';
 import { fetchFormDirectoryNames } from '../services/forms-from-config';
 import Router from 'express-promise-router';
-import { addField } from '../services/custom-forms';
+import { addField, getFormReplacements } from '../services/custom-forms';
 
 const formDefinitionRouter = Router();
 
@@ -10,6 +10,14 @@ formDefinitionRouter.get('/forms', async (_req: Request, res: Response) => {
   const formDirectories = await fetchFormDirectoryNames();
   res.send({ formDirectories });
 });
+
+formDefinitionRouter.get(
+  '/form-replacements',
+  async (_req: Request, res: Response) => {
+    const replacements = await getFormReplacements();
+    res.send({ replacements });
+  },
+);
 
 formDefinitionRouter.get('/:id', async (req: Request, res: Response) => {
   const definition = await fetchFormDefinition(req.params.id);

--- a/controllers/form-definitions.ts
+++ b/controllers/form-definitions.ts
@@ -2,7 +2,11 @@ import { Request, Response } from 'express';
 import { fetchFormDefinition } from '../services/form-definitions';
 import { fetchFormDirectoryNames } from '../services/forms-from-config';
 import Router from 'express-promise-router';
-import { addField, getFormReplacements } from '../services/custom-forms';
+import {
+  addField,
+  deleteFormField,
+  getFormReplacements,
+} from '../services/custom-forms';
 
 const formDefinitionRouter = Router();
 
@@ -37,8 +41,8 @@ formDefinitionRouter.post(
 formDefinitionRouter.delete('/fields', async (req: Request, res: Response) => {
   const formUri = req.body.formUri;
   const fieldUri = req.body.fieldUri;
-  console.log(`deleting field ${formUri} ${fieldUri}`);
-  res.send({ success: true });
+  const newFormData = await deleteFormField(formUri, fieldUri);
+  res.send(newFormData);
 });
 
 export { formDefinitionRouter };

--- a/controllers/form-definitions.ts
+++ b/controllers/form-definitions.ts
@@ -31,17 +31,17 @@ formDefinitionRouter.get('/:id', async (req: Request, res: Response) => {
 formDefinitionRouter.post(
   '/:id/fields',
   async (req: Request, res: Response) => {
-    const body = req.body;
-    const newFormData = await addField(req.params.id, body);
+    const newFormData = await addField(req.params.id, req.body);
     res.send(newFormData);
   },
 );
 
 // this is in semantic forms territory and there we only know uris... we can solve this with contexts if necessary
 formDefinitionRouter.delete('/fields', async (req: Request, res: Response) => {
-  const formUri = req.body.formUri;
-  const fieldUri = req.body.fieldUri;
-  const newFormData = await deleteFormField(formUri, fieldUri);
+  const newFormData = await deleteFormField(
+    req.body.formUri,
+    req.body.fieldUri,
+  );
   res.send(newFormData);
 });
 

--- a/controllers/form-definitions.ts
+++ b/controllers/form-definitions.ts
@@ -7,6 +7,7 @@ import {
   deleteFormField,
   getFormReplacements,
   moveField,
+  updateField,
 } from '../services/custom-forms';
 
 const formDefinitionRouter = Router();
@@ -36,6 +37,10 @@ formDefinitionRouter.post(
     res.send(newFormData);
   },
 );
+formDefinitionRouter.put('/:id/fields', async (req: Request, res: Response) => {
+  const updatedFormData = await updateField(req.params.id, req.body);
+  res.send(updatedFormData);
+});
 
 formDefinitionRouter.post(
   '/:id/fields/move',

--- a/controllers/form-definitions.ts
+++ b/controllers/form-definitions.ts
@@ -6,6 +6,7 @@ import {
   addField,
   deleteFormField,
   getFormReplacements,
+  moveField,
 } from '../services/custom-forms';
 
 const formDefinitionRouter = Router();
@@ -32,6 +33,18 @@ formDefinitionRouter.post(
   '/:id/fields',
   async (req: Request, res: Response) => {
     const newFormData = await addField(req.params.id, req.body);
+    res.send(newFormData);
+  },
+);
+
+formDefinitionRouter.post(
+  '/:id/fields/move',
+  async (req: Request, res: Response) => {
+    const newFormData = await moveField(
+      req.params.id,
+      req.body.fieldUri,
+      req.body.direction,
+    );
     res.send(newFormData);
   },
 );

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -1,2 +1,1 @@
 declare module 'forking-store';
-declare module 'mu';

--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -16,7 +16,7 @@ services:
       - ./:/app
       # ignore app/dist because this is where we map the built files to, otherwise we get an infinite loop of creating files (on mac)
       - /app/dist
-      - ./dist:/build/
+      - ./dist:/usr/src/dist
     networks:
       - debug
 networks:

--- a/domain/data-access/form-extension-repository.ts
+++ b/domain/data-access/form-extension-repository.ts
@@ -308,7 +308,7 @@ const getExtensionFieldLibraryEntries = async (
 
     SELECT DISTINCT ?libraryUri
     WHERE {
-      GRAPH <${graph}> {
+      GRAPH ${sparqlEscapeUri(graph)} {
         ?s a form:Field;
            prov:wasDerivedFrom ?libraryUri.
       }
@@ -377,14 +377,14 @@ const addShapes = async (
     const generatorShapeQuery = `
       PREFIX form: <http://lblod.data.gift/vocabularies/forms/>
       INSERT {
-        GRAPH <${graph}> {
+        GRAPH ${sparqlEscapeUri(graph)} {
           ?shape ${sparqlEscapeUri(p)} [
             a ${sparqlEscapeUri(type)}
           ] .
         }
       }
       WHERE {
-        GRAPH <${graph}> {
+        GRAPH ${sparqlEscapeUri(graph)} {
           ?gen a form:Generator.
           ?gen form:prototype / form:shape ?shape.
         }
@@ -434,7 +434,7 @@ const getExtensionFieldPaths = async (graph: string, store: N3.Store) => {
 
     SELECT DISTINCT ?path
     WHERE {
-      GRAPH <${graph}> {
+      GRAPH ${sparqlEscapeUri(graph)} {
         ?s a form:Field;
            prov:wasDerivedFrom ?libraryUri ;
            sh:path ?path .

--- a/domain/data-access/form-extension-repository.ts
+++ b/domain/data-access/form-extension-repository.ts
@@ -3,8 +3,6 @@ import { quadToString, ttlToStore } from '../../helpers/ttl-helpers';
 import { sparqlEscapeUri, query } from 'mu';
 import N3, { Quad } from 'n3';
 
-import { ttlToStore } from '../../helpers/ttl-helpers';
-
 const engine = new QueryEngine();
 
 const isFormExtension = async (formTtl: string) => {

--- a/domain/data-access/form-repository.ts
+++ b/domain/data-access/form-repository.ts
@@ -50,20 +50,25 @@ const fetchFormTtlById = async (
   }
 };
 
-const fetchFormTtlByUri = async (formUri: string): Promise<string | null> => {
+const fetchFormTtlByUri = async (
+  formUri: string,
+): Promise<{ formTtl: string; custom: boolean } | null> => {
   const result = await query(`
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 
-    SELECT ?formTtl
+    SELECT ?formTtl ?custom
     WHERE {
       ${sparqlEscapeUri(formUri)} a ext:GeneratedForm;
         ext:ttlCode ?formTtl.
+        OPTIONAL {
+          ${sparqlEscapeUri(formUri)} ext:isCustomForm ?custom .
+        }
     } LIMIT 1
   `);
 
   if (result.results.bindings.length) {
     const binding = result.results.bindings[0];
-    return binding.formTtl.value;
+    return { formTtl: binding.formTtl.value, custom: !!binding.custom?.value };
   } else {
     return null;
   }

--- a/domain/data-access/form-repository.ts
+++ b/domain/data-access/form-repository.ts
@@ -19,23 +19,32 @@ import { v4 as uuid } from 'uuid';
 import comunicaRepo from './comunica-repository';
 import { querySudo, updateSudo } from '@lblod/mu-auth-sudo';
 
-const fetchFormTtlById = async (formId: string): Promise<string | null> => {
+const fetchFormTtlById = async (
+  formId: string,
+): Promise<{ formTtl: string; custom: boolean; uri: string } | null> => {
   const result = await query(`
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
     PREFIX sh: <http://www.w3.org/ns/shacl#>
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
 
-    SELECT ?formDefinition ?formTtl
+    SELECT ?formDefinition ?formTtl ?custom
     WHERE {
       ?formDefinition a ext:GeneratedForm ;
         mu:uuid ${sparqlEscapeString(formId)} ;
         ext:ttlCode ?formTtl .
+        OPTIONAL {
+          ?formDefinition ext:isCustomForm ?custom .
+        }
     } LIMIT 1
   `);
 
   if (result.results.bindings.length) {
     const binding = result.results.bindings[0];
-    return binding.formTtl.value;
+    return {
+      formTtl: binding.formTtl.value,
+      custom: !!binding.custom?.value,
+      uri: binding.formDefinition.value,
+    };
   } else {
     return null;
   }

--- a/helpers/ttl-helpers.ts
+++ b/helpers/ttl-helpers.ts
@@ -41,18 +41,21 @@ export const ttlToStore = function (ttl: string): Promise<N3.Store> {
   const parser = new N3.Parser();
 
   return new Promise((resolve, reject) => {
-    parser.parse(ttl, (error, quad) => {
-      if (error) {
-        console.error(error);
-        reject(error);
-        return;
-      }
-      if (!quad) {
-        resolve(store);
-        return;
-      }
-      store.addQuad(quad);
-    });
+    parser.parse(
+      `@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n ${ttl}`,
+      (error, quad) => {
+        if (error) {
+          console.error(error);
+          reject(error);
+          return;
+        }
+        if (!quad) {
+          resolve(store);
+          return;
+        }
+        store.addQuad(quad);
+      },
+    );
   });
 };
 

--- a/helpers/ttl-helpers.ts
+++ b/helpers/ttl-helpers.ts
@@ -22,7 +22,7 @@ export const sparqlEscapeObject = (bindingObject): string => {
 /**
  * The n3 Quad library's writer is not safe enough, let's use the mu encoding functions
  */
-const quadToString = function (quad: Quad) {
+export const quadToString = function (quad: Quad) {
   let object;
   if (quad.object.termType === 'Literal') {
     const datatype = quad.object.datatype;
@@ -36,8 +36,15 @@ const quadToString = function (quad: Quad) {
   )} ${object} .`;
 };
 
-export const ttlToStore = function (ttl: string): Promise<N3.Store> {
-  const store = new N3.Store();
+export const ttlToStore = function (
+  ttl: string,
+  existingStore?: N3.Store,
+  graph?: string,
+): Promise<N3.Store> {
+  let store = existingStore;
+  if (!store) {
+    store = new N3.Store();
+  }
   const parser = new N3.Parser();
 
   return new Promise((resolve, reject) => {
@@ -53,7 +60,7 @@ export const ttlToStore = function (ttl: string): Promise<N3.Store> {
           resolve(store);
           return;
         }
-        store.addQuad(quad);
+        store.addQuad(quad.subject, quad.predicate, quad.object, graph);
       },
     );
   });

--- a/services/custom-forms.ts
+++ b/services/custom-forms.ts
@@ -294,9 +294,9 @@ async function addLibraryFieldToFormExtension(
         
         ?validation ?validationP ?validationO .
         FILTER(?validationP != sh:path)
+        BIND(URI(CONCAT(?validation, ?uuid)) AS ?validationUri).
       }
       BIND(${sparqlEscapeString(id)} AS ?uuid)
-      BIND(URI(CONCAT(?validation, ?uuid)) AS ?validationUri).
     }
   `);
   return { id, uri };

--- a/services/custom-forms.ts
+++ b/services/custom-forms.ts
@@ -297,6 +297,10 @@ async function addFieldToFormExtension(
   const fieldGroupUri = await fetchGroupFromFormTtl(formTtl);
   const safeName = name.replace(/[^a-zA-Z0-9]/g, '');
   const generatedPath = `http://data.lblod.info/id/lmb/form-fields-path/${id}/${safeName}`;
+  const path = sparqlEscapeUri(fieldDescription.path || generatedPath);
+  const requiredConstraintTtl = fieldDescription.isRequired
+    ? getRequiredConstraintInsertTtl(uri, path)
+    : '';
 
   await update(`
     PREFIX form: <http://lblod.data.gift/vocabularies/forms/>
@@ -310,9 +314,11 @@ async function addFieldToFormExtension(
             sh:name ${sparqlEscapeString(name)};
             form:displayType ${sparqlEscapeUri(fieldDescription.displayType)};
             sh:order ${nextOrder};
-            sh:path ${sparqlEscapeUri(fieldDescription.path || generatedPath)};
+            sh:path ${path};
             mu:uuid ${sparqlEscapeString(id)}.
         ${sparqlEscapeUri(formUri)} form:includes ${sparqlEscapeUri(uri)}.
+
+      ${requiredConstraintTtl}
     }
   `);
   return { id, uri };

--- a/services/custom-forms.ts
+++ b/services/custom-forms.ts
@@ -68,19 +68,17 @@ export async function updateField(
     PREFIX sh: <http://www.w3.org/ns/shacl#>
 
     DELETE {
-      ?fieldUri sh:name ?fieldName .
-      ?fieldUri form:displayType ?displayType .
+      ${escaped.fieldUri} sh:name ?fieldName .
+      ${escaped.fieldUri} form:displayType ?displayType .
     }
     INSERT {
-      ?fieldUri sh:name ${escaped.name} .
-      ?fieldUri form:displayType ${escaped.displayType} .
+      ${escaped.fieldUri} sh:name ${escaped.name} .
+      ${escaped.fieldUri} form:displayType ${escaped.displayType} .
     }
     WHERE {
-      ?fieldUri a form:Field ;
+      ${escaped.fieldUri} a form:Field ;
         sh:name ?fieldName ;
         form:displayType ?displayType .
-      
-      BIND(${escaped.fieldUri} AS ?fieldUri)
     }
   `);
   const form = await fetchFormDefinition(formId);

--- a/services/custom-forms.ts
+++ b/services/custom-forms.ts
@@ -13,19 +13,19 @@ import { fetchFormDefinitionByUri } from './forms-from-config';
 import { HttpError } from '../domain/http-error';
 type FieldDescription =
   | {
-    name: string;
-    displayType: string;
-    libraryEntryUri?: never;
-    order?: number;
-    path?: string;
-  }
+      name: string;
+      displayType: string;
+      libraryEntryUri?: never;
+      order?: number;
+      path?: string;
+    }
   | {
-    name: string;
-    displayType?: never;
-    libraryEntryUri: string;
-    order?: number;
-    path?: string;
-  };
+      name: string;
+      displayType?: never;
+      libraryEntryUri: string;
+      order?: number;
+      path?: string;
+    };
 
 export async function addField(formId: string, description: FieldDescription) {
   verifyFieldDescription(description);

--- a/services/custom-forms.ts
+++ b/services/custom-forms.ts
@@ -81,16 +81,10 @@ export async function updateField(
     displayType: sparqlEscapeUri(description.displayType),
   };
   let requiredConstraintInsertTtl = '';
-  let requiredConstraintDeleteTtl = '';
   if (description.isRequired) {
     requiredConstraintInsertTtl = getRequiredConstraintInsertTtl(
       description.field,
     );
-  } else {
-    requiredConstraintDeleteTtl = `
-      ${escaped.fieldUri} form:validatedBy ?validation .
-        ?validation ?validationP ?validationO .
-    `;
   }
 
   await update(`
@@ -101,7 +95,8 @@ export async function updateField(
       ${escaped.fieldUri} sh:name ?fieldName .
       ${escaped.fieldUri} form:displayType ?displayType .
 
-      ${description.isRequired ? '' : requiredConstraintDeleteTtl}
+      ${escaped.fieldUri} form:validatedBy ?validation .
+        ?validation ?validationP ?validationO .
     }
     INSERT {
       ${escaped.fieldUri} sh:name ${escaped.name} .

--- a/services/custom-forms.ts
+++ b/services/custom-forms.ts
@@ -127,7 +127,7 @@ async function updateFieldOrder(fieldUri, fieldsInGroup, direction) {
       const offset = currentIndex - newPosition;
       if (fieldsInGroup[currentIndex].field !== fieldUri) {
         newFieldOrders[fieldsInGroup[currentIndex].field] =
-          parseInt(fieldAtOldPosition.order) + (1 + offset) * direction;
+          parseInt(fieldAtOldPosition.order) - (offset - 1) * direction;
       }
       currentIndex += direction;
     }

--- a/services/custom-forms.ts
+++ b/services/custom-forms.ts
@@ -69,7 +69,7 @@ async function createCustomExtension(formUri: string): Promise<{
 async function addFieldToFormExtension(
   formUri: string,
   formTtl: string,
-  fieldDescription: any,
+  fieldDescription: FieldDescription,
 ) {
   const id = uuidv4();
   const uri = `http://data.lblod.info/id/lmb/form-fields/${id}`;
@@ -146,7 +146,7 @@ async function updateFormTtlForExtension(formUri: string) {
   `);
 
   const resultTtl = result.results.bindings
-    .map((b: any) => {
+    .map((b) => {
       return `${sparqlEscapeUri(b.s.value)} ${sparqlEscapeUri(
         b.p.value,
       )} ${sparqlEscapeObject(b.o)} .`;
@@ -175,19 +175,17 @@ async function markReplacement(
   standardUri: string,
   replacementUri: string,
 ) {
+  const safeReplacement = sparqlEscapeUri(replacementUri);
+  const safeStandard = sparqlEscapeUri(standardUri);
   const query = `
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
     PREFIX form: <http://lblod.data.gift/vocabularies/forms/>
 
     INSERT DATA {
-      ${sparqlEscapeUri(replacementUri)} ext:replacesForm ${sparqlEscapeUri(
-        standardUri,
-      )} .
-      ${sparqlEscapeUri(standardUri)} a form:Form .
-      ${sparqlEscapeUri(standardUri)} mu:uuid ${sparqlEscapeString(
-        standardId,
-      )} .
+      ${safeReplacement} ext:replacesForm ${safeStandard} .
+      ${safeStandard} a form:Form .
+      ${safeStandard} mu:uuid ${sparqlEscapeString(standardId)} .
     }`;
 
   await update(query);
@@ -206,7 +204,7 @@ export async function getFormReplacements() {
     }`;
 
   const result = await query(q);
-  return result.results.bindings.map((b: any) => {
+  return result.results.bindings.map((b) => {
     return {
       standard: b.standard.value,
       replacement: b.replacement.value,

--- a/services/custom-forms.ts
+++ b/services/custom-forms.ts
@@ -13,19 +13,19 @@ import { fetchFormDefinitionByUri } from './forms-from-config';
 import { HttpError } from '../domain/http-error';
 type FieldDescription =
   | {
-      name: string;
-      displayType: string;
-      libraryEntryUri?: never;
-      order?: number;
-      path?: string;
-    }
+    name: string;
+    displayType: string;
+    libraryEntryUri?: never;
+    order?: number;
+    path?: string;
+  }
   | {
-      name: string;
-      displayType?: never;
-      libraryEntryUri: string;
-      order?: number;
-      path?: string;
-    };
+    name: string;
+    displayType?: never;
+    libraryEntryUri: string;
+    order?: number;
+    path?: string;
+  };
 
 export async function addField(formId: string, description: FieldDescription) {
   verifyFieldDescription(description);
@@ -276,14 +276,27 @@ async function addLibraryFieldToFormExtension(
             sh:name ${sparqlEscapeString(fieldDescription.name)} ;
             prov:wasDerivedFrom ${sparqlEscapeUri(libraryEntryUri)} ;
             form:displayType ?displayType ;
+            form:validatedBy ?validationUri ;
             sh:order ${sparqlEscapeInt(99999)} ;
             sh:path ?path ;
-            mu:uuid ${sparqlEscapeString(id)} .
+            mu:uuid ?uuid .
         ${sparqlEscapeUri(formUri)} form:includes ${sparqlEscapeUri(uri)} .
+
+        ?validationUri ?validationP ?validationO .
+        ?validationUri sh:path ?path .
     } WHERE {
       ${sparqlEscapeUri(libraryEntryUri)} a ext:FormLibraryEntry ;
         sh:path ?path ;
         form:displayType ?displayType .
+
+      OPTIONAL {
+        ${sparqlEscapeUri(libraryEntryUri)} form:validatedBy ?validation .
+        
+        ?validation ?validationP ?validationO .
+        FILTER(?validationP != sh:path)
+      }
+      BIND(${sparqlEscapeString(id)} AS ?uuid)
+      BIND(URI(CONCAT(?validation, ?uuid)) AS ?validationUri).
     }
   `);
   return { id, uri };

--- a/services/custom-forms.ts
+++ b/services/custom-forms.ts
@@ -486,6 +486,9 @@ async function updateFormTtlForExtension(formUri: string) {
       ?s ext:ttlCode ${sparqlEscapeString(resultTtl)}.
     }
     WHERE {
+      VALUES ?s {
+        ${sparqlEscapeUri(formUri)}
+      }
       ?s ext:isCustomForm true.
       OPTIONAL {
         ?s ext:ttlCode ?ttl.

--- a/services/custom-forms.ts
+++ b/services/custom-forms.ts
@@ -263,6 +263,7 @@ async function addLibraryFieldToFormExtension(
     throw new HttpError('Library entry not found', 404);
   }
 
+  const escapedUuid = sparqlEscapeString(id);
   await update(`
     PREFIX form: <http://lblod.data.gift/vocabularies/forms/>
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
@@ -279,7 +280,7 @@ async function addLibraryFieldToFormExtension(
             form:validatedBy ?validationUri ;
             sh:order ${sparqlEscapeInt(99999)} ;
             sh:path ?path ;
-            mu:uuid ?uuid .
+            mu:uuid ${escapedUuid} .
         ${sparqlEscapeUri(formUri)} form:includes ${sparqlEscapeUri(uri)} .
 
         ?validationUri ?validationP ?validationO .
@@ -294,9 +295,8 @@ async function addLibraryFieldToFormExtension(
         
         ?validation ?validationP ?validationO .
         FILTER(?validationP != sh:path)
-        BIND(URI(CONCAT(?validation, ?uuid)) AS ?validationUri).
+        BIND(URI(CONCAT(?validation, ${escapedUuid})) AS ?validationUri).
       }
-      BIND(${sparqlEscapeString(id)} AS ?uuid)
     }
   `);
   return { id, uri };

--- a/services/custom-forms.ts
+++ b/services/custom-forms.ts
@@ -355,6 +355,7 @@ async function updateFormTtlForExtension(formUri: string) {
     ?s ?p ?o.
     ?field ?fieldP ?fieldO.
     ?field ext:isExtensionField true.
+    ?validation ?vP ?vO.
   }
   WHERE {
     VALUES ?s {
@@ -364,6 +365,11 @@ async function updateFormTtlForExtension(formUri: string) {
     OPTIONAL {
       ?s form:includes ?field.
       ?field ?fieldP ?fieldO.
+
+      OPTIONAL {
+        ?field form:validatedBy ?validation.
+        ?validation ?vP ?vO.
+      }
     }
     FILTER(?p NOT IN (ext:ttlCode))
   }

--- a/services/custom-forms.ts
+++ b/services/custom-forms.ts
@@ -11,12 +11,21 @@ import { sparqlEscapeObject, ttlToStore } from '../helpers/ttl-helpers';
 import { fetchFormDefinition } from './form-definitions';
 import { fetchFormDefinitionByUri } from './forms-from-config';
 import { HttpError } from '../domain/http-error';
-type FieldDescription = {
-  name: string;
-  displayType: string;
-  order?: number;
-  path?: string;
-};
+type FieldDescription =
+  | {
+      name: string;
+      displayType: string;
+      libraryEntryId?: never;
+      order?: number;
+      path?: string;
+    }
+  | {
+      name: string;
+      displayType?: never;
+      libraryEntryId: string;
+      order?: number;
+      path?: string;
+    };
 
 export async function addField(formId: string, description: FieldDescription) {
   verifyFieldDescription(description);
@@ -39,8 +48,16 @@ function verifyFieldDescription(description: FieldDescription) {
   if (!description.name || description.name.trim().length === 0) {
     throw new HttpError('Field description must have a name', 400);
   }
-  if (!description.displayType || description.displayType.trim().length === 0) {
-    throw new HttpError('Field description must have a display type', 400);
+  const noDisplayType =
+    !description.displayType || description.displayType.trim().length === 0;
+  const noLibraryEntry =
+    !description.libraryEntryId ||
+    description.libraryEntryId.trim().length === 0;
+  if (noDisplayType && noLibraryEntry) {
+    throw new HttpError(
+      'Field description must have a display type or a library entry id',
+      400,
+    );
   }
 }
 

--- a/services/custom-forms.ts
+++ b/services/custom-forms.ts
@@ -1,0 +1,117 @@
+import { FormDefinition } from '../types';
+import { fetchFormDefinition } from './form-definitions';
+import { v4 as uuidv4 } from 'uuid';
+import {
+  query,
+  update,
+  sparqlEscapeUri,
+  sparqlEscapeString,
+  sparqlEscapeInt,
+} from 'mu';
+import { sparqlEscapeObject } from '../helpers/ttl-helpers';
+
+// TODO add a type definition for what we want field descriptions to look like
+export async function addField(formId: string, description: any) {
+  let form = await fetchFormDefinition(formId);
+  let uri = form.uri;
+  if (!form.custom) {
+    const created = await createCustomExtension(form.uri);
+    uri = created.uri;
+  }
+  await addFieldToFormExtension(uri, form.formTtl, description);
+  await updateFormTtlForExtension(uri);
+  form = await fetchFormDefinition(formId);
+  return form;
+}
+
+async function createCustomExtension(formUri: string): Promise<{
+  id: string;
+  uri: string;
+}> {
+  const id = uuidv4();
+  const uri = `http://data.lblod.info/id/lmb/forms/${id}`;
+
+  await update(`
+    PREFIX form: <http://lblod.data.gift/vocabularies/forms/>
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+    INSERT DATA {
+        ${sparqlEscapeUri(uri)} a form:Extension;
+            ext:extendsForm ${sparqlEscapeUri(formUri)};
+            ext:isCustomForm true;
+            mu:uuid ${sparqlEscapeString(id)}.
+    }
+  `);
+  return { id, uri };
+}
+
+async function addFieldToFormExtension(
+  formUri: string,
+  formTtl: string,
+  fieldDescription: any,
+) {
+  const id = uuidv4();
+  const uri = `http://data.lblod.info/id/lmb/form-fields/${id}`;
+  const name = fieldDescription.name;
+  // find right field group from form ttl
+  const fieldGroupUri = `http://data.lblod.info/id/lmb/form-field-groups/${id}`;
+  const safeName = name.replace(/[^a-zA-Z0-9]/g, '');
+  const generatedPath = `http://data.lblod.info/id/lmb/form-fields-path/${id}/${safeName}`;
+
+  await update(`
+    PREFIX form: <http://lblod.data.gift/vocabularies/forms/>
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+    PREFIX sh: <http://www.w3.org/ns/shacl#>
+
+    INSERT DATA {
+        ${sparqlEscapeUri(uri)} a form:Field;
+            ext:extendsGroup ${sparqlEscapeUri(fieldGroupUri)};
+            sh:name ${sparqlEscapeString(name)};
+            form:displayType ${sparqlEscapeUri(fieldDescription.displayType)};
+            sh:order ${sparqlEscapeInt(fieldDescription.order)};
+            sh:path ${sparqlEscapeUri(fieldDescription.path || generatedPath)};
+            mu:uuid ${sparqlEscapeString(id)}.
+    }
+  `);
+  return { id, uri };
+}
+
+async function updateFormTtlForExtension(formUri: string) {
+  const result = await query(`
+  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+  CONSTRUCT {
+    ?s ?p ?o.
+  }
+  WHERE {
+    VALUES ?s {
+      ${sparqlEscapeUri(formUri)}
+    }
+    ?s ?p ?o.
+    FILTER(?p NOT IN (ext:ttlCode))
+  }
+  `);
+
+  const resultTtl = result.results.bindings
+    .map((b: any) => {
+      return `${sparqlEscapeUri(b.s.value)} ${sparqlEscapeUri(
+        b.p.value,
+      )} ${sparqlEscapeObject(b.o)} .`;
+    })
+    .join('\n');
+  await update(`
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+    DELETE {
+      ?s ext:ttlCode ?ttl.
+    }
+    INSERT {
+      ?s ext:ttlCode ${sparqlEscapeString(resultTtl)}.
+    }
+    WHERE {
+      ?s ext:isCustomForm true.
+      ?s ext:ttlCode ?ttl.
+    }
+  `);
+}

--- a/services/custom-forms.ts
+++ b/services/custom-forms.ts
@@ -63,6 +63,8 @@ export async function addField(formId: string, description: FieldDescription) {
   await addFieldToFormExtension(uri, form.formTtl, description);
   await updateFormTtlForExtension(uri);
   form = await fetchFormDefinition(modifiedFormId);
+  await getGeneratorShape(form.formTtl);
+
   return form;
 }
 
@@ -560,4 +562,34 @@ async function deleteFieldFromFormExtension(formUri: string, fieldUri: string) {
         ${sparqlEscapeUri(fieldUri)} ?p ?o.
     }
   `);
+}
+
+async function getGeneratorShape(formTtl: string) {
+  const store = await ttlToStore(formTtl);
+  const engine = new QueryEngine();
+
+  const query = `
+  PREFIX form: <http://lblod.data.gift/vocabularies/forms/>
+  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+  PREFIX sh: <http://www.w3.org/ns/shacl#>
+
+  SELECT ?shape WHERE {
+    ?generator a form:Generator ;
+      form:prototype / form:shape ?shape .
+  }`;
+  const bindingStream = await engine.queryBindings(query, {
+    sources: [store],
+  });
+  const bindings = await bindingStream.toArray();
+  if (!bindings.length) {
+    return null;
+  }
+  const b = bindings[0];
+  if (b.get('shape').termType === 'BlankNode') {
+    throw new HttpError(
+      'Generator shape is a blank node. Cannot extend the form with this field.',
+      500,
+    );
+  }
+  return b.get('shape').value;
 }

--- a/services/form-definitions.ts
+++ b/services/form-definitions.ts
@@ -8,8 +8,11 @@ export const fetchFormDefinition = async (id: string) => {
     formDefinition.formTtl,
   );
   return {
+    id,
+    uri: formDefinition.uri,
     formTtl: `@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n${formDefinition.formTtl}`,
     metaTtl: `@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n${formDefinition.metaTtl}`,
+    custom: formDefinition.custom,
     prefix,
     withHistory,
   };

--- a/services/form-extensions.ts
+++ b/services/form-extensions.ts
@@ -49,6 +49,8 @@ export const extendForm = async (
 
   await formExtRepo.replaceFormUri(mergeGraph, store);
   await formExtRepo.replaceExtendsGroup(mergeGraph, store);
+  await formExtRepo.addExtensionFieldGenerators(mergeGraph, store);
+  await formExtRepo.addComplexPaths(mergeGraph, store);
 
   const extendedFormTtl = await formExtRepo.graphToTtl(mergeGraph, store);
 

--- a/services/form-extensions.ts
+++ b/services/form-extensions.ts
@@ -5,6 +5,7 @@ import { fetchFormDefinitionByUri } from './forms-from-config';
 import { FormDefinition } from '../types';
 
 export const extendForm = async (
+  extensionUri: string,
   extensionFormTtl: string,
 ): Promise<FormDefinition> => {
   const store = new N3.Store();
@@ -14,6 +15,7 @@ export const extendForm = async (
     return {
       formTtl: extensionFormTtl,
       metaTtl: null,
+      uri: extensionUri,
     };
   }
 
@@ -53,6 +55,7 @@ export const extendForm = async (
   return {
     formTtl: extendedFormTtl,
     metaTtl: baseFormDefinition.metaTtl,
+    uri: extensionUri,
   };
 };
 

--- a/services/forms-from-config.ts
+++ b/services/forms-from-config.ts
@@ -61,9 +61,11 @@ export const fetchFormDefinitionByUri = async (
     return fetchFormDefinitionById(formId);
   }
 
-  const formTtl = await formRepo.fetchFormTtlByUri(formUri);
+  const result = await formRepo.fetchFormTtlByUri(formUri);
 
-  if (!formTtl) throw new HttpError('Definition not found', 404);
+  if (!result) throw new HttpError('Definition not found', 404);
+
+  const { formTtl, custom } = result;
 
   const formDefinition = await extendForm(formUri, formTtl);
 
@@ -77,6 +79,7 @@ export const fetchFormDefinitionByUri = async (
   return {
     formTtl: formDefinition.formTtl,
     uri: formDefinition.uri,
+    custom: formDefinition.custom || custom,
     metaTtl,
   };
 };

--- a/types.ts
+++ b/types.ts
@@ -1,6 +1,8 @@
 export type FormDefinition = {
   formTtl: string;
   metaTtl?: string | null;
+  custom?: boolean;
+  uri: string;
 };
 
 export type Label = {


### PR DESCRIPTION
## Description

Allows the creation of custom form extensions by adding fields to forms and removing fields that have been added in this way (only from custom forms)

## How to test

see https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/449