### PR TITLE
LMB-1218 | Find and remove usages of the form definition

### DIFF
--- a/controllers/form-definitions.ts
+++ b/controllers/form-definitions.ts
@@ -5,6 +5,7 @@ import {
   createEmptyFormDefinition,
   fetchFormDefinition,
   findFormUsages,
+  removeFormDefinitionUsage,
 } from '../services/form-definitions';
 import { fetchFormDirectoryNames } from '../services/forms-from-config';
 import {
@@ -93,6 +94,15 @@ formDefinitionRouter.get(
       hasUsage: usageUris?.length >= 1,
       usageUris,
     });
+  },
+);
+
+formDefinitionRouter.delete(
+  '/definition/:id/usage',
+  async (req: Request, res: Response) => {
+    await removeFormDefinitionUsage(req.params.id);
+
+    res.status(204).send({});
   },
 );
 

--- a/controllers/form-definitions.ts
+++ b/controllers/form-definitions.ts
@@ -4,6 +4,7 @@ import { Request, Response } from 'express';
 import {
   createEmptyFormDefinition,
   fetchFormDefinition,
+  findFormUsages,
 } from '../services/form-definitions';
 import { fetchFormDirectoryNames } from '../services/forms-from-config';
 import {
@@ -80,6 +81,18 @@ formDefinitionRouter.post(
       req.body.description || null,
     );
     res.status(201).send({ id });
+  },
+);
+
+formDefinitionRouter.get(
+  '/definition/:id/has-usage',
+  async (req: Request, res: Response) => {
+    const usageUris = await findFormUsages(req.params.id);
+
+    res.status(200).send({
+      hasUsage: usageUris?.length >= 1,
+      usageUris,
+    });
   },
 );
 

--- a/controllers/form-definitions.ts
+++ b/controllers/form-definitions.ts
@@ -4,7 +4,7 @@ import { Request, Response } from 'express';
 import {
   createEmptyFormDefinition,
   fetchFormDefinition,
-  findFormUsages,
+  getFormUsageCount,
   removeFormDefinitionUsage,
 } from '../services/form-definitions';
 import { fetchFormDirectoryNames } from '../services/forms-from-config';
@@ -86,13 +86,13 @@ formDefinitionRouter.post(
 );
 
 formDefinitionRouter.get(
-  '/definition/:id/has-usage',
+  '/definition/:id/usage-count',
   async (req: Request, res: Response) => {
-    const usageUris = await findFormUsages(req.params.id);
+    const usageCount = await getFormUsageCount(req.params.id);
 
     res.status(200).send({
-      hasUsage: usageUris?.length >= 1,
-      usageUris,
+      hasUsage: usageCount >= 1,
+      count: usageCount,
     });
   },
 );

--- a/controllers/form-instances.ts
+++ b/controllers/form-instances.ts
@@ -4,10 +4,10 @@ import {
   createHistoryForInstance,
   deleteFormInstance,
   fetchInstanceAndForm,
-  findUsageOfForm,
   getHistoryForInstance,
   getHistoryInstance,
   getInstancesForForm,
+  getInstanceUsageCount,
   postFormInstance,
   updateFormInstance,
 } from '../services/form-instances';
@@ -118,13 +118,13 @@ formInstanceRouter.delete(
 );
 
 formInstanceRouter.get(
-  '/instance/:id/has-usage',
+  '/instance/:id/usage-count',
   async (req: Request, res: Response) => {
-    const usageUris = await findUsageOfForm(req.params.id);
+    const usageCount = await getInstanceUsageCount(req.params.id);
 
     res.status(200).send({
-      hasUsage: usageUris?.length >= 1,
-      usageUris,
+      hasUsage: usageCount >= 1,
+      count: usageCount,
     });
   },
 );

--- a/controllers/form-instances.ts
+++ b/controllers/form-instances.ts
@@ -4,6 +4,7 @@ import {
   createHistoryForInstance,
   deleteFormInstance,
   fetchInstanceAndForm,
+  findUsageOfForm,
   getHistoryForInstance,
   getHistoryInstance,
   getInstancesForForm,
@@ -113,6 +114,18 @@ formInstanceRouter.delete(
   async (req: Request, res: Response) => {
     await deleteFormInstance(req.params.id, req.params.instanceId);
     res.sendStatus(200);
+  },
+);
+
+formInstanceRouter.get(
+  '/instance/:id/has-usage',
+  async (req: Request, res: Response) => {
+    const usageUris = await findUsageOfForm(req.params.id);
+
+    res.status(200).send({
+      hasUsage: usageUris?.length >= 1,
+      usageUris,
+    });
   },
 );
 

--- a/services/form-definitions.ts
+++ b/services/form-definitions.ts
@@ -139,3 +139,34 @@ export const findFormUsages = async (formId: string) => {
 
   return Array.from(new Set(results.map((b) => b.usage?.value)));
 };
+
+export const removeFormDefinitionUsage = async (formId: string) => {
+  const queryString = `
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+    PREFIX form: <http://lblod.data.gift/vocabularies/forms/>
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+    DELETE {
+      GRAPH ?g {
+        ?instance ?p ?o .
+      }
+    }
+    WHERE {
+      GRAPH ?g {
+        ?form mu:uuid ${sparqlEscapeString(formId)}.
+        ?definition form:targetType ?targetType .
+
+        ?instance a ?targetType .
+        ?instance ?p ?o .
+      }
+    }
+  `;
+  try {
+    await update(queryString);
+  } catch (error) {
+    throw new HttpError(
+      `Something went wrong while removing the form with usages (${formId})`,
+      500,
+    );
+  }
+};

--- a/services/form-definitions.ts
+++ b/services/form-definitions.ts
@@ -138,24 +138,20 @@ export const removeFormDefinitionUsage = async (formId: string) => {
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 
     DELETE {
-      GRAPH ?g {
-        ?instance ?p ?o .
-        ?s ?pp ?instance .
-      }
+      ?instance ?p ?o .
+      ?s ?pp ?instance .
     }
     WHERE {
-      GRAPH ?g {
-        ?form mu:uuid ${sparqlEscapeString(formId)}.
-        ?definition form:targetType ?targetType .
+      ?form mu:uuid ${sparqlEscapeString(formId)}.
+      ?definition form:targetType ?targetType .
 
-        OPTIONAL {
-          ?instance a ?targetType .
-          ?instance ?p ?o .
-        }
+      OPTIONAL {
+        ?instance a ?targetType .
+        ?instance ?p ?o .
+      }
 
-        OPTIONAL {
-          ?s ?pp ?instance .
-        }
+      OPTIONAL {
+        ?s ?pp ?instance .
       }
     }
   `);

--- a/services/form-definitions.ts
+++ b/services/form-definitions.ts
@@ -141,18 +141,22 @@ export const removeFormDefinitionUsage = async (formId: string) => {
       ?instance ?p ?o .
       ?s ?pp ?instance .
     }
+    INSERT {
+      ?instance a <http://www.w3.org/ns/activitystreams#Tombstone> ;
+         <http://www.w3.org/ns/activitystreams#deleted> ?now ;
+         <http://www.w3.org/ns/activitystreams#formerType> ?targetType .
+    }
     WHERE {
       ?form mu:uuid ${sparqlEscapeString(formId)}.
-      ?definition form:targetType ?targetType .
+      ?form form:targetType ?targetType .
 
-      OPTIONAL {
-        ?instance a ?targetType .
-        ?instance ?p ?o .
-      }
+      ?instance a ?targetType .
+      ?instance ?p ?o .
 
       OPTIONAL {
         ?s ?pp ?instance .
       }
+      BIND(NOW() AS ?now)
     }
   `);
 };

--- a/services/form-instances.ts
+++ b/services/form-instances.ts
@@ -254,28 +254,20 @@ export const instancesAsCsv = async (
   return jsonToCsv(withNullReplaced);
 };
 
-export const findUsageOfForm = async (instanceId: string) => {
-  let results = [];
+export const getInstanceUsageCount = async (instanceId: string) => {
   const queryString = `
       PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
       PREFIX form: <http://lblod.data.gift/vocabularies/forms/>
       PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
   
-      SELECT DISTINCT ?usage
+      SELECT (COUNT(DISTINCT ?usage) AS ?count)
       WHERE {
         ?instance mu:uuid ${sparqlEscapeString(instanceId)} .
         ?usage ?p ?instance .
       }
     `;
-  try {
-    const queryResult = await query(queryString);
-    results = queryResult.results.bindings;
-  } catch (error) {
-    throw new HttpError(
-      `Something went wrong while fetching usages for instance with id: ${instanceId}`,
-      500,
-    );
-  }
+  const queryResult = await query(queryString);
+  const count = queryResult.results.bindings?.at(0)?.count.value || '0';
 
-  return Array.from(new Set(results.map((b) => b.usage?.value)));
+  return parseInt(count);
 };


### PR DESCRIPTION
## Description

Now that we can create edit form definitions and instances we also need to remove them properly.  These endpoints will help the frontend to handle the removal of the forms/instances of a form.

## How to test

1. Use it together with the frontend
2. Queries should be fast
3. All remains of the form/instances should be removed

## Links to other PR's

- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/524
