### PR TITLE
LMB-1500 | Custom form fields can be conceptscheme selector

### DIFF
--- a/services/custom-forms.ts
+++ b/services/custom-forms.ts
@@ -31,6 +31,7 @@ type FieldDescription =
       path?: string;
       isRequired?: boolean;
       showInSummary?: boolean;
+      conceptScheme?: string;
     }
   | {
       name: string;
@@ -40,6 +41,7 @@ type FieldDescription =
       path?: string;
       isRequired?: boolean;
       showInSummary?: boolean;
+      conceptScheme?: string;
     };
 type FieldUpdateDescription = {
   field: string;
@@ -47,6 +49,7 @@ type FieldUpdateDescription = {
   displayType: string;
   isRequired: boolean;
   showInSummary?: boolean;
+  conceptScheme?: string;
 };
 
 const getRequiredConstraintInsertTtl = (fieldUri: string, path?: string) => {
@@ -263,6 +266,15 @@ async function updateFieldOrder(fieldUri, fieldsInGroup, direction) {
   `);
 }
 
+const isConceptSchemeRequiredField = (displayType: string) => {
+  const displayTypes = [
+    'http://lblod.data.gift/display-types/lmb/custom-concept-scheme-selector-input',
+    'http://lblod.data.gift/display-types/lmb/custom-concept-scheme-multi-selector-input',
+  ];
+
+  return displayTypes.includes(displayType);
+};
+
 function verifyFieldDescription(description: FieldDescription) {
   if (!description.name || description.name.trim().length === 0) {
     throw new HttpError('Field description must have a name', 400);
@@ -275,6 +287,16 @@ function verifyFieldDescription(description: FieldDescription) {
   if (noDisplayType && noLibraryEntry) {
     throw new HttpError(
       'Field description must have a display type or a library entry id',
+      400,
+    );
+  }
+
+  if (
+    isConceptSchemeRequiredField(description.displayType) &&
+    !description.conceptScheme
+  ) {
+    throw new HttpError(
+      `Field description must have a conceptScheme. This is required for field type "${description.displayType}"`,
       400,
     );
   }

--- a/services/custom-forms.ts
+++ b/services/custom-forms.ts
@@ -362,12 +362,19 @@ async function addFieldToFormExtension(
   const showInSummaryTtl = fieldDescription.showInSummary
     ? `${sparqlEscapeUri(uri)} form:showInSummary true .`
     : '';
+  let conceptSchemeTtl = '';
+  if (isConceptSchemeRequiredField(fieldDescription.displayType)) {
+    const conceptSchemeUri = sparqlEscapeUri(fieldDescription.conceptScheme);
+    conceptSchemeTtl = `
+      ${sparqlEscapeUri(uri)} fieldOption:conceptScheme ${conceptSchemeUri} .`;
+  }
 
   await update(`
     PREFIX form: <http://lblod.data.gift/vocabularies/forms/>
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
     PREFIX sh: <http://www.w3.org/ns/shacl#>
+    PREFIX fieldOption: <http://lblod.data.gift/vocabularies/form-field-options/>
 
     INSERT DATA {
         ${sparqlEscapeUri(uri)} a form:Field;
@@ -382,6 +389,7 @@ async function addFieldToFormExtension(
 
       ${requiredConstraintTtl}
       ${showInSummaryTtl}
+      ${conceptSchemeTtl}
     }
   `);
   return { id, uri };


### PR DESCRIPTION
## Description

We want to enable the field option to have a conceptscheme added to it. This makes it possible to show conceptscheme selector in the frontend.

## How to test

Together with the frontend you should be able to add a conceptscheme to a codelist field.

## Links to other PR's

- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/410
- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/528
