### PR TITLE
lmb-1529 | Removing a field is possible for all isCustom fields

### DIFF
--- a/services/custom-forms.ts
+++ b/services/custom-forms.ts
@@ -670,14 +670,13 @@ async function deleteFieldFromFormExtension(formUri: string, fieldUri: string) {
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 
     DELETE {
-        ${sparqlEscapeUri(formUri)} form:includes ${sparqlEscapeUri(fieldUri)}.
-        ${sparqlEscapeUri(fieldUri)} ?p ?o.
+      ${sparqlEscapeUri(formUri)} form:includes ${sparqlEscapeUri(fieldUri)}.
+      ${sparqlEscapeUri(fieldUri)} ?p ?o.
     }
     WHERE {
-        ${sparqlEscapeUri(formUri)} a form:Extension;
-          ext:isCustomForm true;
-          form:includes ${sparqlEscapeUri(fieldUri)}.
-        ${sparqlEscapeUri(fieldUri)} ?p ?o.
+      ${sparqlEscapeUri(formUri)} ext:isCustomForm true .
+      ${sparqlEscapeUri(formUri)} form:includes ${sparqlEscapeUri(fieldUri)} .
+      ${sparqlEscapeUri(fieldUri)} ?p ?o.
     }
   `);
 }


### PR DESCRIPTION
## Description

We could not remove custom fields from custom forms as it checked if the type was a form:Extension. This is not necessary, isCustom is enough.

## How to test

Remove a field from a custom form + form extension

## Links to other PR's

- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/540
