### PR TITLE
lmb-1515: add ext:isCustomForm to the generated forms

### DIFF
--- a/controllers/form-instances.ts
+++ b/controllers/form-instances.ts
@@ -73,6 +73,7 @@ formInstanceRouter.post(
     }
     const labels = await getFormInstanceLabels(formDefinitionId);
     const formInstances = await getInstancesForFormByUris(formDefinitionId, {
+      limit,
       offset,
       sort,
       filter,

--- a/domain/data-access/comunica-repository.ts
+++ b/domain/data-access/comunica-repository.ts
@@ -115,7 +115,7 @@ export const getFormLabels = async (formTtl: string): Promise<Label[]> => {
       // we need to do this because we want to possibly filter on certain values
       // so the client will send a string that is transformed in the same way
       var:
-        binding.get('labelName')?.value.replace(/ /g, '')?.toLowerCase() ??
+        binding.get('labelName')?.value.replace(/\W/g, '')?.toLowerCase() ??
         'label',
       type: binding.get('displayType')?.value ?? '',
       uri: binding.get('labelUri')?.value ?? '',
@@ -162,7 +162,7 @@ export const getDefaultFormLabels = async (
       // so the client will send a string that is transformed in the same way
       type: binding.get('displayType')?.value ?? '',
       var:
-        binding.get('labelName')?.value.replace(/ /g, '')?.toLowerCase() ??
+        binding.get('labelName')?.value.replace(/\W/g, '')?.toLowerCase() ??
         'label',
       uri: binding.get('labelUri')?.value ?? '',
     };

--- a/services/custom-forms.ts
+++ b/services/custom-forms.ts
@@ -818,7 +818,7 @@ export async function getFormInstanceLabels(
   const customFormLabels = result?.results?.bindings.map((b) => {
     return {
       name: b.fieldName?.value,
-      var: b.fieldName?.value.replace(/ /g, '')?.toLowerCase(),
+      var: b.fieldName?.value.replace(/\W/g, '')?.toLowerCase(),
       uri: b.fieldValuePath?.value,
       type: b.displayType?.value,
       isShownInSummary: !!b.showInSummary?.value,

--- a/services/form-definitions.ts
+++ b/services/form-definitions.ts
@@ -99,6 +99,7 @@ export async function createEmptyFormDefinition(
       form:targetType ${sparqlEscapeUri(typeUri)} ;
       form:targetLabel mu:uuid ;
       ext:prefix ${sparqlEscapeUri(prefixUri)} ;
+      ext:isCustomForm """true"""^^xsd:boolean ;
       mu:uuid ${sparqlEscapeString(id)} .
     
     ${generatorTtl}


### PR DESCRIPTION
## Description

Add missing predicate on creation of custom form

## How to test

When creating an "eigen" form the first field should also have the predicate isCustomForm and you should see the show in summary toggle

## Links to other PR's

- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/564
- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/437
