### PR TITLE
lmb-1593 | add end point to check if the form definition is used in a custom form configuration

### DIFF
--- a/controllers/form-definitions.ts
+++ b/controllers/form-definitions.ts
@@ -5,6 +5,7 @@ import {
   createEmptyFormDefinition,
   fetchFormDefinition,
   getFormUsageCount,
+  isFormTypeUsedInCustomFormConfiguration,
   removeFormDefinitionUsage,
 } from '../services/form-definitions';
 import { fetchFormDirectoryNames } from '../services/forms-from-config';
@@ -100,6 +101,14 @@ formDefinitionRouter.get(
       hasUsage: usageCount >= 1,
       count: usageCount,
     });
+  },
+);
+formDefinitionRouter.get(
+  '/definition/:id/used-in-custom-form-configuration',
+  async (req: Request, res: Response) => {
+    const isUsed = await isFormTypeUsedInCustomFormConfiguration(req.params.id);
+
+    res.status(200).send(isUsed);
   },
 );
 

--- a/controllers/form-definitions.ts
+++ b/controllers/form-definitions.ts
@@ -106,9 +106,13 @@ formDefinitionRouter.get(
 formDefinitionRouter.get(
   '/definition/:id/used-in-custom-form-configuration',
   async (req: Request, res: Response) => {
-    const isUsed = await isFormTypeUsedInCustomFormConfiguration(req.params.id);
+    const { hasUsage, formLabels } =
+      await isFormTypeUsedInCustomFormConfiguration(req.params.id);
 
-    res.status(200).send(isUsed);
+    res.status(200).send({
+      hasUsage,
+      formLabels,
+    });
   },
 );
 

--- a/controllers/form-definitions.ts
+++ b/controllers/form-definitions.ts
@@ -6,7 +6,7 @@ import {
   fetchFormDefinition,
   getFormUsageCount,
   isFormTypeUsedInCustomFormConfiguration,
-  removeFormDefinitionUsage,
+  removeFormDefinitionAndUsage,
 } from '../services/form-definitions';
 import { fetchFormDirectoryNames } from '../services/forms-from-config';
 import {
@@ -119,7 +119,7 @@ formDefinitionRouter.get(
 formDefinitionRouter.delete(
   '/definition/:id/usage',
   async (req: Request, res: Response) => {
-    await removeFormDefinitionUsage(req.params.id);
+    await removeFormDefinitionAndUsage(req.params.id);
 
     res.status(204).send({});
   },

--- a/services/form-definitions.ts
+++ b/services/form-definitions.ts
@@ -159,6 +159,27 @@ export const getFormUsageCount = async (formId: string) => {
   return parseInt(count);
 };
 
+export const isFormTypeUsedInCustomFormConfiguration = async (
+  formId: string,
+) => {
+  const queryString = `
+      PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+      PREFIX form: <http://lblod.data.gift/vocabularies/forms/>
+      PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+      ASK {
+        ?form mu:uuid ${sparqlEscapeString(formId)}.
+        ?form form:targetType ?targetType .
+
+        ?field ext:linkedFormType ?form .
+      }
+    `;
+  const queryResult = (await query(queryString)) as unknown as {
+    boolean: boolean;
+  };
+  return queryResult.boolean;
+};
+
 export const removeFormDefinitionUsage = async (formId: string) => {
   await update(`
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>

--- a/services/form-definitions.ts
+++ b/services/form-definitions.ts
@@ -203,7 +203,6 @@ export const removeFormDefinitionAndUsage = async (formId: string) => {
   await update(`
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
     PREFIX form: <http://lblod.data.gift/vocabularies/forms/>
-    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 
     DELETE {
       ?s ?pp ?instance .
@@ -221,15 +220,15 @@ export const removeFormDefinitionAndUsage = async (formId: string) => {
   await update(`
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
     PREFIX form: <http://lblod.data.gift/vocabularies/forms/>
-    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+    PREFIX astreams: <http://www.w3.org/ns/activitystreams#>
 
     DELETE {
       ?instance ?p ?o .
     }
     INSERT {
-      ?instance a <http://www.w3.org/ns/activitystreams#Tombstone> ;
-         <http://www.w3.org/ns/activitystreams#deleted> ?now ;
-         <http://www.w3.org/ns/activitystreams#formerType> ?targetType .
+      ?instance a astreams:Tombstone .
+      ?instance astreams:deleted ?now .
+      ?instance astreams:formerType ?targetType .
     }
     WHERE {
       ?form mu:uuid ${sparqlEscapeString(formId)} .
@@ -243,16 +242,15 @@ export const removeFormDefinitionAndUsage = async (formId: string) => {
   await update(`
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
     PREFIX form: <http://lblod.data.gift/vocabularies/forms/>
-    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
-    PREFIX streams: <http://www.w3.org/ns/activitystreams#>
+    PREFIX astreams: <http://www.w3.org/ns/activitystreams#>
 
     DELETE {
       ?form ?fp ?fo .
     }
     INSERT {
-      ?form a streams:Tombstone ;
-        streams:deleted ?now ;
-        streams:formerType ?type .
+      ?form a astreams:Tombstone .
+      ?form astreams:deleted ?now .
+      ?form astreams:formerType ?type .
     }
     WHERE {
       ?form mu:uuid ${sparqlEscapeString(formId)} .

--- a/services/form-definitions.ts
+++ b/services/form-definitions.ts
@@ -213,8 +213,6 @@ export const removeFormDefinitionAndUsage = async (formId: string) => {
 
       ?instance a ?targetType .
       ?s ?pp ?instance .
-
-      BIND(NOW() AS ?now)
     }
   `);
   await update(`


### PR DESCRIPTION
## Description

We need a check to see if the form is used in configuration of a custom form so we can disallow it to be removed.

## How to test

Use the frontend PR to see if the usages are found

## Links to other PR's

- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/577
