### PR TITLE
LMB-1532 | summary fields should be ordered

### DIFF
--- a/services/custom-forms.ts
+++ b/services/custom-forms.ts
@@ -798,7 +798,7 @@ export async function getFormInstanceLabels(
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
     PREFIX sh: <http://www.w3.org/ns/shacl#>
 
-    SELECT ?field ?fieldName ?fieldValuePath ?displayType ?showInSummary
+    SELECT ?field ?fieldName ?fieldValuePath ?displayType ?showInSummary ?order
     WHERE {
       GRAPH ?g {
         ${fieldsSource}
@@ -807,6 +807,9 @@ export async function getFormInstanceLabels(
         ?field sh:path ?fieldValuePath .
         ?field form:displayType ?displayType .
 
+        OPTIONAL {
+          ?field sh:order ?order .
+        }
         OPTIONAL {
           ?field form:showInSummary ?showInSummary .
         }
@@ -823,16 +826,20 @@ export async function getFormInstanceLabels(
       type: b.displayType?.value,
       isShownInSummary: !!b.showInSummary?.value,
       isCustom: true,
+      order: b.order?.value ? parseInt(b.order.value) : null,
     };
   });
 
   let order = 2;
-  const labelsWithOrder = [...instanceLabels, ...customFormLabels].map(
-    (label) => {
-      return { ...label, order: order++ };
-    },
-  );
+  const labelsWithOrder = [...instanceLabels, ...customFormLabels]
+    .map((label) => {
+      if (label.order) {
+        return label;
+      }
 
+      return { ...label, order: order++ };
+    })
+    .sort((a, b) => a.order - b.order);
   return [
     { name: 'Uri', var: 'uri', uri: null, order: 0 },
     {

--- a/services/form-instances.ts
+++ b/services/form-instances.ts
@@ -273,7 +273,6 @@ export const instancesAsCsv = async (
     limit?: number;
   } = { limit: 9999 }, // Get all instances
 ): Promise<string> => {
-  console.log({ labels });
   const result = await getInstancesForForm(formId, {
     labels,
     ...options,

--- a/services/form-instances.ts
+++ b/services/form-instances.ts
@@ -6,6 +6,7 @@ import formRepo from '../domain/data-access/form-repository';
 import comunicaRepo from '../domain/data-access/comunica-repository';
 import { fetchUserIdFromSession } from '../domain/data-access/user-repository';
 import { jsonToCsv } from '../utils/json-to-csv-string';
+import { getFormInstanceLabels } from './custom-forms';
 
 import { query, sparqlEscapeString } from 'mu';
 
@@ -76,6 +77,11 @@ export const getInstancesForForm = async (
   if (!labels || labels.length === 0) {
     labels = await comunicaRepo.getDefaultFormLabels(form.formTtl);
   }
+  const allLabelsWithOrder = await getFormInstanceLabels(formId);
+  const labelVariables = labels.map((l) => l.var);
+  labels = allLabelsWithOrder.filter((label) =>
+    labelVariables.includes(label.var),
+  );
 
   return await formRepo.getFormInstancesWithCount(type, labels, options);
 };


### PR DESCRIPTION
## Description

Summary fields should always follow the order of the fields

- instances table
- configure columns 
- link to instance list

## How to test

1. create a custom form and add showInSummary to atleast 2 fields
2. These field labels should be shown in the instances table in the order of the fields
3. Move the fields around, and the instance table + configuration should follow this order
4. When linking to a form you have the table that show the selected and the table that shows all instances, make sure these are also following the order

## Links to other PR's

- https://github.com/lblod/ember-semantic-forms/pull/9
- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/578
