### PR TITLE
docs: add warning note that complex paths are not working!

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ These forms can be created by using the available endpoints. If you want a more 
 
 > Note: when a path is not specified when adding fields they get a generated path
 
+> ⚠️ Note: complex paths are broken at the moment, this means that if the sh:path object is a class value it won't set the value correctly!
+
 <details>
   <summary>Example form ttl (1*)</summary>
 


### PR DESCRIPTION
## Description

In Lokaal Mandatenbeheer we used to have this library field with a complex path. With all the updates of addons this broke this functionality. 

Example of this complex path
```ttl
    <http://data.lblod.info/id/lmb/form-library-entries/0bdd360b-c6e5-46d9-9a31-8645a4c5774c> a ext:FormLibraryEntry ;
     mu:uuid "0bdd360b-c6e5-46d9-9a31-8645a4c5774c" ;
     sh:name "Sterfdatum" ;
     form:displayType <http://lblod.data.gift/display-types/lmb/custom-date-input> ;
     sh:path <http://data.lblod.info/id/lmb/paths/574867d1-3422-41a9-8648-34dc2c443204> ;
     ext:needsShape <http://data.lblod.info/id/lmb/shapes/d56503fc-96d4-49fc-8425-e36db36fd172> ;
     ext:needsGenerator <http://data.lblod.info/id/lmb/generators/3afc0fad-e475-4696-ae50-3627fed41cf8> ;
     sh:order 1000 .

    <http://data.lblod.info/id/lmb/paths/574867d1-3422-41a9-8648-34dc2c443204> rdf:first <http://data.vlaanderen.be/ns/persoon#heeftOverlijden> ;
      rdf:rest <http://data.lblod.info/id/lmb/paths/0c65e9c8-0910-490a-96e7-19b71290b91a> .
    <http://data.lblod.info/id/lmb/paths/0c65e9c8-0910-490a-96e7-19b71290b91a> rdf:first <http://data.vlaanderen.be/ns/persoon#datum> ;
      rdf:rest rdf:nil .

    <http://data.lblod.info/id/lmb/shapes/d56503fc-96d4-49fc-8425-e36db36fd172> <http://data.vlaanderen.be/ns/persoon#heeftOverlijden> <http://data.lblod.info/id/lmb/shapes/048663a1-6b73-4346-8267-0f40e0dff9f4> .

    <http://data.lblod.info/id/lmb/shapes/048663a1-6b73-4346-8267-0f40e0dff9f4> a <http://data.vlaanderen.be/ns/persoon#Overlijden> .

    <http://data.lblod.info/id/lmb/generators/3afc0fad-e475-4696-ae50-3627fed41cf8> a form:UriGenerator;
      form:prefix "http://data.lblod.info/id/overlijden/";
      form:forType persoon:Overlijden.
